### PR TITLE
ajenti: install new version of ajenti

### DIFF
--- a/roles/ajenti/tasks/main.yml
+++ b/roles/ajenti/tasks/main.yml
@@ -13,7 +13,7 @@
     - pkg: gcc
 
 - name: install ajenti from Pypi
-  pip: name=https://github.com/migonzalvar/ajenti/releases/download/0.99.34-patched3/ajenti-0.99.34-patched3.tar.gz
+  pip: name=https://github.com/migonzalvar/ajenti/releases/download/0.99.34-patched3/ajenti-0.99.34-patched5.tar.gz
 
 - name: install python-catcher
   pip: name=python-catcher version=0.1.3


### PR DESCRIPTION
Install 0.99.34-patched5 version of ajenti. That version handles cookie with invalid UTF-8 values. Fixes #5.
