### PR TITLE
ajenti: fix a typo in ajenti download URL

### DIFF
--- a/roles/ajenti/tasks/main.yml
+++ b/roles/ajenti/tasks/main.yml
@@ -13,7 +13,7 @@
     - pkg: gcc
 
 - name: install ajenti from Pypi
-  pip: name=https://github.com/migonzalvar/ajenti/releases/download/0.99.34-patched3/ajenti-0.99.34-patched5.tar.gz
+  pip: name=https://github.com/migonzalvar/ajenti/releases/download/0.99.34-patched5/ajenti-0.99.34-patched5.tar.gz
 
 - name: install python-catcher
   pip: name=python-catcher version=0.1.3


### PR DESCRIPTION
I'm sorry I had a typo in the download URL and now the install procedure is broke. Please, merge to fix it.

We can discuss later an alternative way like configure a custom Python packages repository for XSCE or even package as a rpm.
