### PR TITLE
create link to multi-user.target for default.target

### DIFF
--- a/roles/common/tasks/xo.yml
+++ b/roles/common/tasks/xo.yml
@@ -67,8 +67,10 @@
               state=absent
 
 - name: Disable graphical login
-  service: name=olpc-dm
-           enabled=no
+  file: path=/etc/systemd/system/default.target
+        src=/lib/systemd/system/multi-user.target
+        state=link
+  tags: test
   register: disabled_login
 
 - name: Reboot system 


### PR DESCRIPTION
This replaces one method of disabling graphical gui with another. Previously the olpc-dm.service was disabled. The replacement changes the systemd default.target to multi-user.target.  This change is required so that "init 5" can be used on an xo to bring up the network neighborhood, and enter connection credentials. "init 3" goes back to text mode. I verified that this change does not affect sensing that the display setting has been changed, and therefore does not affect the reboot.
