### PR TITLE
common: update chrony package and use template instead of lineinfile

### DIFF
--- a/roles/common/tasks/chrony.yml
+++ b/roles/common/tasks/chrony.yml
@@ -4,17 +4,9 @@
   with_items:
    - chrony
 
-- name: Set chrony subnet, so that the clients may "ping and sync" with DXS.
-  lineinfile: backup=yes
-              dest=/etc/chrony.conf
-              state=present
-              regexp='^#allow 192.168/16' 
-              line='allow 172.18'
-
-- name: Add stratum configuration to chrony
-  lineinfile: backup=yes
-              dest=/etc/chrony.conf
-              state=present
-              regexp='^#local stratum 10'
-              line='local stratum 10'
+#TODO: Use regexp filter instead of hard-code ip 
+- name: Update chrony config file
+  template: backup=yes
+            dest=/etc/chrony.conf
+            src=chrony.conf.j2
 

--- a/roles/common/templates/chrony.conf.j2
+++ b/roles/common/templates/chrony.conf.j2
@@ -1,0 +1,46 @@
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+server 0.fedora.pool.ntp.org iburst
+server 1.fedora.pool.ntp.org iburst
+server 2.fedora.pool.ntp.org iburst
+server 3.fedora.pool.ntp.org iburst
+
+# Ignore stratum in source selection.
+stratumweight 0
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Enable kernel RTC synchronization.
+rtcsync
+
+# In first three updates step the system clock instead of slew
+# if the adjustment is larger than 10 seconds.
+makestep 10 3
+
+# Allow NTP client access from local network.
+allow 172.18
+
+# Listen for commands only on localhost.
+bindcmdaddress 127.0.0.1
+bindcmdaddress ::1
+
+# Serve time even if not synchronized to any NTP server.
+local stratum 10
+
+keyfile /etc/chrony.keys
+
+# Specify the key used as password for chronyc.
+commandkey 1
+
+# Generate command key if missing.
+generatecommandkey
+
+# Disable logging of client accesses.
+noclientlog
+
+# Send a message to syslog if a clock adjustment is larger than 0.5 seconds.
+logchange 0.5
+
+#log measurements statistics tracking
+logdir /var/log/chrony


### PR DESCRIPTION
chrony playbook was changing config file with every run, converted to template.
