### PR TITLE
httpd: ansible fact is a string so need quotes

### DIFF
--- a/roles/httpd/templates/php.ini.j2
+++ b/roles/httpd/templates/php.ini.j2
@@ -516,7 +516,7 @@ doc_root =
 user_dir =
 
 ; Directory in which the loadable extensions (modules) reside.
-{% if ansible_userspace_bits == 64 %}
+{% if ansible_userspace_bits == "64" %}
 extension_dir = "/usr/lib64/php/modules"
 {% else %}
 extension_dir = "/usr/lib/php/modules"


### PR DESCRIPTION
The fact `ansible_userspace_bits` is a string so it needs quotes
