### PR TITLE
Grant read permission to all users in network flag files

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -36,6 +36,7 @@
   template: backup=yes
             src={{ item }}.j2
             dest=/etc/sysconfig/{{ item }}
+            mode=0644
   with_items:
     - xs_wan_device
     - xs_lan_device


### PR DESCRIPTION
At least xs_domain_name must be read by apache user.

IMHO, ready to merge.
