### PR TITLE
avahi: remove rfb announce file

### DIFF
--- a/roles/common/tasks/avahi.yml
+++ b/roles/common/tasks/avahi.yml
@@ -10,13 +10,6 @@
     - download
 
 - name: Install avahi announce config files
-  template: backup=yes
-            src=rfb.service
-            dest=/etc/avahi/services/rfb.service
-            owner=avahi
-            group=avahi
-            mode=640
-           
   template: backup=yes 
             src=schoolserver.service
             dest=/etc/avahi/services/schoolserver.service

--- a/roles/common/templates/rfb.service
+++ b/roles/common/templates/rfb.service
@@ -1,9 +1,0 @@
-<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
-<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
-<service-group>
-<name replace-wildcards="yes">%h VNC</name>
-<service>
-<type>_rfb._tcp</type>
-<port>5901</port>
-</service>
-</service-group>


### PR DESCRIPTION
Remove uninstalled (?) VNC service announcement file.

Anyway, this file wasn't being installed because the action in https://github.com/XSCE/xsce/blob/71aef1/roles/common/tasks/avahi.yml#L19 lacks a `- name: bla bla` line.

Please, @scollazo and @jvonau take a look.
