### PR TITLE
pathagar: ensure pathagar is not installed using a rpm

### DIFF
--- a/roles/pathagar/tasks/main.yml
+++ b/roles/pathagar/tasks/main.yml
@@ -1,3 +1,6 @@
+- name: Remove if exist pathagar rpm version
+  yum: name=pathagar state=absent
+
 - name: Install pathagar pre requisites
   yum: name={{ item }}
        state=latest


### PR DESCRIPTION
Make sure pathagar is not installed using a rpm as done in previous XSCE release.
