### PR TITLE
ajenti: install python-imaging from rpm package instead of PIL from PyPI

### DIFF
--- a/roles/ajenti/tasks/main.yml
+++ b/roles/ajenti/tasks/main.yml
@@ -6,6 +6,7 @@
   yum: name={{ item.pkg }}
        state=installed
   with_items:
+    - pkg: python-imaging
     - pkg: python-devel
     - pkg: libxslt-devel
     - pkg: pyOpenSSL


### PR DESCRIPTION
Solves issue XSCE/xsce#102.
