### PR TITLE
Env override

### DIFF
--- a/roles/common/library/xsce_facts
+++ b/roles/common/library/xsce_facts
@@ -9,7 +9,7 @@ fi
 if [ -n "$lan_device_override" ]; then
     LAN=$lan_device_override
 else
-    LAN=`/sbin/ip link show  | grep mtu | awk -F":" '{print \$2}' | grep -v -e lo -e $WAN| tr -d ' '  | head -n1` 
+    LAN=`/sbin/ip link show  | grep -v -e DOWN -e lo -e $WAN | grep mtu | awk -F":" '{print \$2}' |  tr -d ' '  | head -n1` 
 fi
 
 WAN_MAC=`/sbin/ip addr show $WAN | /bin/awk '/link\/ether/ { print \$2}' | tr [:lower:] [:upper:]`

--- a/roles/common/library/xsce_facts
+++ b/roles/common/library/xsce_facts
@@ -1,7 +1,16 @@
 #!/bin/bash
 
-WAN=`/sbin/ip route ls | awk '{if($1=="default")print $5}' | tr -d ' '`
-LAN=`/sbin/ip link show  | grep mtu | awk -F":" '{print \$2}' | grep -v -e lo -e $WAN| tr -d ' '  | head -n1` 
+if [ -n "$wan_device_override" ]; then
+    WAN=$wan_device_override
+else
+    WAN=`/sbin/ip route ls | awk '{if($1=="default")print $5}' | tr -d ' '`
+fi
+
+if [ -n "$lan_device_override" ]; then
+    LAN=$lan_device_override
+else
+    LAN=`/sbin/ip link show  | grep mtu | awk -F":" '{print \$2}' | grep -v -e lo -e $WAN| tr -d ' '  | head -n1` 
+fi
 
 WAN_MAC=`/sbin/ip addr show $WAN | /bin/awk '/link\/ether/ { print \$2}' | tr [:lower:] [:upper:]`
 LAN_MAC=`/sbin/ip addr show $LAN | /bin/awk '/link\/ether/ { print \$2}' | tr [:lower:] [:upper:]`

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,5 +1,6 @@
 - name: Get XSCE facts
   xsce_facts: facts=true
+  environment: env
   tags: 
     - facts
     - common
@@ -13,6 +14,8 @@
     - download
     - services
     - squid
+
+- action: pause
 
 - name: Set hostname
   template: backup=yes

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -15,8 +15,6 @@
     - services
     - squid
 
-- action: pause
-
 - name: Set hostname
   template: backup=yes
             dest=/etc/hostname

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -2,6 +2,7 @@
 lan_ip: 172.18.96.1
 lan_netmask: 255.255.224.0
 
+# put in non-null device names in the following to override auto-detection
 env:
    lan_device_override: ""
    wan_device_override: ""

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -2,6 +2,10 @@
 lan_ip: 172.18.96.1
 lan_netmask: 255.255.224.0
 
+env:
+   lan_device_override: ""
+   wan_device_override: ""
+
 watchdog: 
   - sshd
   - idmgr


### PR DESCRIPTION
This PR allows the user to edit by hand the vars/default_vars.yml, and thus override the auto-detection of the network adapters. It also prevents choosing as a LAN device, one that has been declared down via "ifconfig wlan0 down".

Probably too late for 0.5, but I found it useful setting up a maachine for the Haiti trip.