### PR TITLE
ajenti: restart to assure is up

### DIFF
--- a/roles/ajenti/tasks/main.yml
+++ b/roles/ajenti/tasks/main.yml
@@ -44,4 +44,4 @@
 - name: start ajenti service
   service: name=ajenti
            enabled=yes
-           state=started
+           state=restarted


### PR DESCRIPTION
If only started is required, ajenti doesn't come up right.

I detected wrong behaviour in a x86_64 virtual machine. In any case, I think using `state=restarted` instead of `state=started` won't break anything.
