### PR TITLE
ajenti: restart when needed using handlers

### DIFF
--- a/roles/ajenti/handlers/main.yml
+++ b/roles/ajenti/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart ajenti service
+  service: name=ajenti
+           enabled=yes
+           state=restarted

--- a/roles/ajenti/tasks/ajenti-wondershaper.yml
+++ b/roles/ajenti/tasks/ajenti-wondershaper.yml
@@ -2,7 +2,5 @@
   pip: name=https://github.com/migonzalvar/ajenti-plugin-wondershaper/archive/0.3.tar.gz
   tags:
     - download
-
-- name: restart ajenti service
-  service: name=ajenti
-           state=restarted
+  notify:
+    - restart ajenti service

--- a/roles/ajenti/tasks/main.yml
+++ b/roles/ajenti/tasks/main.yml
@@ -19,6 +19,8 @@
   pip: name=https://github.com/migonzalvar/ajenti/releases/download/0.99.34-patched5/ajenti-0.99.34-patched5.tar.gz
   tags:
     - download
+  notify:
+    - restart ajenti service
 
 - name: install python-catcher
   pip: name=python-catcher version=0.1.3
@@ -40,8 +42,3 @@
 
 - include: ajenti-wondershaper.yml
   when: 'xsce_lan_iface != ""'
-
-- name: start ajenti service
-  service: name=ajenti
-           enabled=yes
-           state=started


### PR DESCRIPTION
Just restart one time when wondershaper plugin is installed.

Also use restarted instead of started because the first time ajenti doesn't load correctly. If only started is required, ajenti doesn't come up right.

I detected wrong behaviour in a x86_64 virtual machine. In any case, I think using `state=restarted` instead of `state=started` won't break anything.
