### PR TITLE
[REVIEW] Minor fix to awk call in xsce_facts

### DIFF
--- a/roles/common/library/xsce_facts
+++ b/roles/common/library/xsce_facts
@@ -3,8 +3,8 @@
 WAN=`/sbin/ip route ls | awk '{if($1=="default")print $5}' | tr -d ' '`
 LAN=`/sbin/ip link show  | grep mtu | awk -F":" '{print \$2}' | grep -v -e lo -e $WAN| tr -d ' '  | head -n1` 
 
-WAN_MAC=`/sbin/ip addr show $WAN | /bin/awk '/link\/ether/ { print \$2}' | tr [:lower:] [:upper:]`
-LAN_MAC=`/sbin/ip addr show $LAN | /bin/awk '/link\/ether/ { print \$2}' | tr [:lower:] [:upper:]`
+WAN_MAC=`/sbin/ip addr show $WAN | awk '/link\/ether/ { print \$2}' | tr [:lower:] [:upper:]`
+LAN_MAC=`/sbin/ip addr show $LAN | awk '/link\/ether/ { print \$2}' | tr [:lower:] [:upper:]`
 
 
 if [ -f /proc/device-tree/mfg-data/MN ]


### PR DESCRIPTION
In an effort to be os-agnostic, the awk call in xsce_facts needs to not refer to an absolute path. This fix will help it run in other distros (like ubuntu).
