### PR TITLE
[REVIEW] sugar-stats: use stats-consolidation package from PyPI

### DIFF
--- a/roles/sugar-stats/tasks/statistics-consolidation.yml
+++ b/roles/sugar-stats/tasks/statistics-consolidation.yml
@@ -5,7 +5,7 @@
     - download
 
 - name: Install statistics-consolidation with pip
-  pip: name=git+https://github.com/migonzalvar/statistics-consolidation.git@sqlalchemy-v2#egg=stats_consolidation
+  pip: name=stats-consolidation version=2.1.2
   tags:
     - download
 


### PR DESCRIPTION
Instead of installing stats-consolidation from a personal repository use a specific packaged version from Python Package Index.
