### PR TITLE
ansible: add connection type to inventory file

### DIFF
--- a/ansible_hosts
+++ b/ansible_hosts
@@ -1,2 +1,2 @@
 [localhost]
-127.0.0.1
+127.0.0.1	ansible_connection=local

--- a/docs/CONFIG.rst
+++ b/docs/CONFIG.rst
@@ -123,7 +123,7 @@ Finding out available tags
 **************************
 * The easiest way to find out available tags is to try to call a tag you know doesn't exist.  Then the error will spit out all the available tags.
 
-  ``-bash-4.2# ansible-playbook -i ansible_hosts xsce.yml --connection=local --tags="whatever"``
+  ``-bash-4.2# ansible-playbook -i ansible_hosts xsce.yml --tags="whatever"``
   ``ERROR: tag(s) not found in playbook: whatever.  possible values: activity-server,addons,ajenti,avahi,common,core,dhcpd,download,ejabberd,facts,gateway,httpd,idmgr,iiab,monit,moodle,munin,named,network,olpc,pathagar,portal,postgresql,services,squid,sugar-stats,wondershaper,xo``
 
 ***********************

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -95,7 +95,7 @@ Using tags
 * To avoid replaying all the playbooks, you can use tags to restrict which tasks are run: 
 ::
 
-  ansible-playbook -i ansible_hosts xsce.yml --connection=local --tags="facts,squid"
+  ansible-playbook -i ansible_hosts xsce.yml --tags="facts,squid"
 * Avaliable tags are:``activity-server, addons, ajenti, avahi, common, core, dhcpd, download, ejabberd, facts, gateway, httpd, idmgr, iiab, monit, moodle, munin, named, network, olpc, pathagar, portal, postgresql, services, squid, sugar-stats, wondershaper, xo``
 
 

--- a/runansible
+++ b/runansible
@@ -37,7 +37,7 @@ then
 fi
 
 export ANSIBLE_LOG_PATH="xsce-install.log"
-ansible -m setup -i $INVENTORY localhost --connection=local >> /dev/null
+ansible -m setup -i $INVENTORY localhost  >> /dev/null
 bash $CWD/roles/common/library/xsce_facts >> $ANSIBLE_LOG_PATH
 
-ansible-playbook -i $INVENTORY $PLAYBOOK ${ARGS} --connection=local 
+ansible-playbook -i $INVENTORY $PLAYBOOK ${ARGS} 


### PR DESCRIPTION
Now, we can avoid adding --connection=local every time we run ansible.
