### PR TITLE
Remove ignore errors option on xs-authserver install and specify version to install

### DIFF
--- a/roles/authserver/tasks/main.yml
+++ b/roles/authserver/tasks/main.yml
@@ -5,7 +5,7 @@
     - download
 
 - name: install xs-authserver from pypi
-  pip: name=xs-authserver
+  pip: name=xs-authserver==0.1.7
   tags:
     - download
 

--- a/roles/authserver/tasks/main.yml
+++ b/roles/authserver/tasks/main.yml
@@ -40,7 +40,6 @@
 
 - name: init database
   command: xs-authserverctl initdb
-  ignore_errors: yes
   environment:
     XS_AUTHSERVER_DATABASE: /var/lib/xs-authserver/data.db
 


### PR DESCRIPTION
Two changes:

- remove ignore errors option on xs-authserver because the issue when re running the task is solved upstream
- specify version number to install