### PR TITLE
Unleash

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -26,8 +26,8 @@
   tags:
     - download
   with_items:
-    - http://xsce.activitycentral.com/repos/xsce-release.repo
-    - http://xsce.activitycentral.com/repos/xsce-extra.repo
+    - http://download.unleashkids.org/xsce/repos/xsce-release.repo
+    - http://download.unleashkids.org/xsce/repos/xsce-extra.repo
 
 - include: xo.yml
   when: ansible_distribution_release == "based on Fedora 18"


### PR DESCRIPTION
I changed the pointers to the unleashkids repo files. And then ran through a normal successful install on an XO4. I think we should go ahead and merge this PR soon, so that RC5 works again after the demise of activity central
