### PR TITLE
pathagar should not move httpd error log, particularly if it becomes an ...

### DIFF
--- a/roles/pathagar/templates/pathagar.conf
+++ b/roles/pathagar/templates/pathagar.conf
@@ -26,8 +26,5 @@ WSGIScriptAlias {{ pathagar_subpath }} {{ pathagar_dir }}/wsgi.py
 </Directory>
 
 
-ErrorLog /var/log/httpd/pathagar-error.log
-LogLevel warn
-
 CustomLog /var/log/httpd/pathagar-access.log combined
 ServerSignature On


### PR DESCRIPTION
While debugging the malfunction of ds-backup, I discovered that pathagar had moved the httpd errorlog to /var/log/httpd/pathagar-error.log.  I think the httpd errorlog should not be hidden in a file named for an optional add-in.
