### PR TITLE
Change target xovis git repo for xsce install.

### DIFF
--- a/roles/xovis/vars/main.yml
+++ b/roles/xovis/vars/main.yml
@@ -13,5 +13,5 @@ xovis_db_url: "http://{{ xovis_db_login }}@{{ xovis_target_host }}/{{ xovis_db_n
 
 xovis_root: "/opt/xovis"
 xovis_backup_dir: "/library/users"
-xovis_repo_url: "https://github.com/martasd/xovis.git"
+xovis_repo_url: "https://github.com/XSCE/xovis.git"
 xovis_chart_heading: "My School: Usage Data Visualization"

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -52,5 +52,6 @@ xovis_db_login: "{{ xovis_db_user }}:{{ xovis_db_password }}"
 xovis_db_url: "http://{{ xovis_db_login }}@{{ xovis_target_host }}/{{ xovis_db_name }}"
 
 xovis_root: "/opt/xovis"
-xovis_repo_url: "https://github.com/martasd/xovis.git"
+xovis_backup_dir: "/library/users"
+xovis_repo_url: "https://github.com/XSCE/xovis.git"
 xovis_chart_heading: "My School: Usage Data Visualization"


### PR DESCRIPTION
Change xsce xovis install from https://github.com/martasd/xovis.git to fork https://github.com/XSCE/xovis.git.

This will allow continued development of original xovis repo without affecting installs for a particular release of xsce.
