### PR TITLE
Rename whitelist

### DIFF
--- a/roles/gateway/templates/squid/sites.whitelist.txt
+++ b/roles/gateway/templates/squid/sites.whitelist.txt
@@ -1,3 +1,4 @@
+# the leading dot matches anything preceeding
 .laptop.org
 .olpcMAP.net
 .mapmeld.appspot.com


### PR DESCRIPTION
Somehow the change back to sites.whitelist.txt did not occur, and Adam's install bombed.
