### PR TITLE
bump version of elgg

### DIFF
--- a/roles/elgg/vars/main.yml
+++ b/roles/elgg/vars/main.yml
@@ -1,4 +1,4 @@
-elgg_xx: elgg-1.8.19
+elgg_xx: elgg-1.9.2
 
 elgg_mysql_password: ElggPassword
 


### PR DESCRIPTION
When I first looked at the elgg site, 1.9.2 was in testing. Now it is recommended. 
