### PR TITLE
add schoolserver/xsce, --/downloads, --/pip-packages, --/yum-packages

### DIFF
--- a/roles/2-common/tasks/prelim.yml
+++ b/roles/2-common/tasks/prelim.yml
@@ -27,6 +27,34 @@
         mode=0755
         state=directory
 
+- name: Create /opt/schoolserver/xsce
+  file: path={{ xsce_dir }}
+        owner=root
+        group=root
+        mode=0755
+        state=directory
+
+- name: Create /opt/schoolserver/yum-packages
+  file: path={{ yum_packages_dir }}
+        owner=root
+        group=root
+        mode=0755
+        state=directory
+
+- name: Create /opt/schoolserver/pip-packages
+  file: path={{ pip_packages_dir }}
+        owner=root
+        group=root
+        mode=0755
+        state=directory
+
+- name: Create /opt/schoolserver/downloads
+  file: path={{ downloads_dir }}
+        owner=root
+        group=root
+        mode=0755
+        state=directory
+
 - name: Disable root login with password 
   lineinfile: backup=yes
               dest=/etc/ssh/sshd_config


### PR DESCRIPTION
I think the typos are gone. I did the first part of a normal install on my vm.
