### PR TITLE
update the vim-minimal, because ejabberd/erlang fails to resolve conflic...

### DIFF
--- a/roles/2-common/tasks/yum.yml
+++ b/roles/2-common/tasks/yum.yml
@@ -38,6 +38,7 @@
   with_items:
    - iptables
    - NetworkManager
+   - vim-minimal # ejabberd erlang does not update this properly
   tags:
     - download
 


### PR DESCRIPTION
...t --yum dependencies in fc20 fail. I've encountered this a few times, and just upgraded vim-minimal by hand. but the right thing is to include it in master
