### PR TITLE
put mysqladmin and elgg in downloads, rather than tmp

### DIFF
--- a/roles/elgg/tasks/main.yml
+++ b/roles/elgg/tasks/main.yml
@@ -1,8 +1,8 @@
-- name: Get the ELGG software 
-  get_url: url=http://download.unleashkids.org/xsce/downloads/{{ elgg_xx }}.zip  dest=/tmp/{{ elgg_xx }}.zip 
+ name: Get the ELGG software 
+  get_url: url=http://download.unleashkids.org/xsce/downloads/{{ elgg_xx }}.zip  dest={{ downloads_dir}}/{{ elgg_xx }}.zip 
 
 - name: Copy it to permanent location /opt
-  unarchive: src=/tmp/{{ elgg_xx }}.zip  dest=/opt/ 
+  unarchive: src={{ downloads_dir}}/{{ elgg_xx }}.zip  dest=/opt/ 
 
 - name: Create a symbolic link to the folder of the current version elgg_xx
   file: path=/opt/elgg src=./{{ elgg_xx }} state=link

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -57,10 +57,10 @@
       lineinfile: line="date.timezone = {{ local_tz }}" dest=/etc/php.ini
 
     - name: Get the phpmyadmin software 
-      get_url: url=http://download.unleashkids.org/xsce/downloads/phpMyAdmin-4.2.7.1-all-languages.zip  dest=/tmp/phpMyAdmin.zip 
+      get_url: url=http://download.unleashkids.org/xsce/downloads/phpMyAdmin-4.2.7.1-all-languages.zip  dest={{ downloads_dir}}/phpMyAdmin.zip 
 
     - name: Copy it to permanent location /opt
-      unarchive: src=/tmp/phpMyAdmin.zip  dest=/opt/ 
+      unarchive: src={{ downloads_dir}}/phpMyAdmin.zip  dest=/opt/ 
 
     - name: Create a symbolic link to the folder of the current version phpmyadmin
       file: path=/opt/phpmyadmin src=phpMyAdmin-4.2.7.1-all-languages state=link


### PR DESCRIPTION
I think I did this before I had really incorporated the concept of using a permanent download folder. This is not tested, but I think it will cleanup the XO4 install
