### PR TITLE
Owncloud via .tar

### DIFF
--- a/roles/ajenti/tasks/ajenti-wondershaper.yml
+++ b/roles/ajenti/tasks/ajenti-wondershaper.yml
@@ -1,5 +1,5 @@
 - name: download wondershaper ajenti plugin
-  pip: name=http://"{{ xsce_download_url }}"/ajenti-plugin-wondershaper-0.3.tar.gz
+  pip: name="{{ xsce_download_url }}"/ajenti-plugin-wondershaper-0.3.tar.gz
         extra_args="--download-cache {{ pip_packages_dir }}"
 
 - name: install wondershaper from local download directory

--- a/roles/ajenti/tasks/main.yml
+++ b/roles/ajenti/tasks/main.yml
@@ -14,7 +14,7 @@
     - pkg: gcc
 
 - name: download ajenti from our repo 
-  pip: name=http://"{{ xsce_download_url }}"/ajenti-0.99.34-patched5.tar.gz
+  pip: name="{{ xsce_download_url }}"/ajenti-0.99.34-patched5.tar.gz
           extra_args="--download-cache={{ pip_packages_dir }}" 
   tags:
     - download

--- a/roles/kiwix/tasks/kiwix_install.yml
+++ b/roles/kiwix/tasks/kiwix_install.yml
@@ -1,5 +1,5 @@
 - name: Get the kiwix software 
-  get_url: url="http://{{ xsce_download_url }}/{{ kiwix_src_file }}"  dest="{{ downloads_dir }}/{{ kiwix_src_file }}"
+  get_url: url="{{ xsce_download_url }}/{{ kiwix_src_file }}"  dest="{{ downloads_dir }}/{{ kiwix_src_file }}"
 
 - name: Unarchive it to permanent location
   unarchive: src="{{ downloads_dir }}/{{ kiwix_src_file }}"  

--- a/roles/owncloud/README.rst
+++ b/roles/owncloud/README.rst
@@ -1,0 +1,28 @@
+===============
+Owncloud README
+===============
+
+This role installs Owncloud, a local cloud type server to share files, calendars, and contact.
+
+
+
+Configuration Parameters
+------------------------
+
+The following are set as defaults in var/mail.yml:
+
+* owncloud_install: True
+* owncloud_enabled: False
+* owncloud_path: "/opt/owncloud"
+* owncloud_data_dir: /library/owncloud/data
+* owncloud_src_file: owncloud-7.0.4.tar.bz2
+
+
+Access and Installation Wizard
+------------------------------
+
+After the ansible installation completes, you can access Owncloud at http://schoolserve/owncloud.
+
+On first access you will be presented with a form to fill in the admin user name and password to 
+complete the install.  After that completes you will see the file sharing space and be able to
+add additional users.

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -1,8 +1,36 @@
+# we need to install the rpm in order to get the dependencies
+
 - name: Install owncloud package
   yum: pkg={{ item }} state=installed
   with_items:
   - owncloud
 
+- name: Remove /etc/owncloud to avoid confusion as we use the config in {{ owncloud_path }}/config/
+  file: path=/etc/owncloud
+        state=absent
+
+# but we use the tar file to get the latest version; really only benefits the xo4 on fedora 18
+
+- name: Get the owncloud software 
+  get_url: url="{{ xsce_download_url }}"/{{ owncloud_src_file }}  dest={{ downloads_dir}}/{{ owncloud_src_file }}
+
+- name: Copy it to permanent location /opt
+  unarchive: src={{ downloads_dir}}/{{ owncloud_src_file}}  dest=/opt/ 
+
+- name: Add autoconfig file
+  template: src=autoconfig.php.j2
+            dest={{ owncloud_path }}/config/autoconfig.php
+            owner=apache
+            group=apache
+            mode=0640
+            
+- name: Make apache owner
+  file: path={{ owncloud_path }}
+        owner=apache
+        group=apache
+        recurse=yes
+        state=directory
+        
 - name: Create data directory library
   file: path={{ item }}
         mode=0750
@@ -11,13 +39,6 @@
         state=directory
   with_items:
     - "{{ owncloud_data_dir }}"
-
-- name: Add autoconfig file
-  template: src=autoconfig.php.j2
-            dest=/etc/owncloud/autoconfig.php
-            owner=apache
-            group=apache
-            mode=0640
     
 - name: Remove httpd conf file in case we are now disabled
   file: path=/etc/httpd/conf.d/owncloud.conf
@@ -39,7 +60,9 @@
     - option: description
       value: '"OwnCloud is a local server-based facility for sharing files, photos, contacts, calendars, etc."'      
     - option: path
-      value: /usr/share/owncloud
+      value: "{{ owncloud_path }}"
+    - option: source
+      value: "{{ owncloud_src_file }}"  
     - option: enabled
       value: "{{ owncloud_enabled }}"  
 

--- a/roles/owncloud/templates/autoconfig.php.j2
+++ b/roles/owncloud/templates/autoconfig.php.j2
@@ -7,5 +7,8 @@ $AUTOCONFIG = array(
      1 => "{{ xsce_hostname }}",
      2 => 'localhost',    
     ),
-  "overwrite.cli.url" => '',  
+  "overwrite.cli.url" => '',
+  "dbtype"        => "sqlite",
+  "dbname"        => "owncloud",
+  "dbtableprefix" => "",  
 );

--- a/roles/owncloud/templates/owncloud.conf.j2
+++ b/roles/owncloud/templates/owncloud.conf.j2
@@ -1,6 +1,6 @@
-Alias /owncloud /usr/share/owncloud
+Alias /owncloud {{ owncloud_path }}
 
-<Directory /usr/share/owncloud/>
+<Directory {{ owncloud_path }}/>
     Options -Indexes
 
     <IfModule mod_authz_core.c>

--- a/roles/owncloud/vars/main.yml
+++ b/roles/owncloud/vars/main.yml
@@ -1,4 +1,5 @@
 owncloud_install: True
 owncloud_enabled: False
+owncloud_path: "/opt/owncloud"
 owncloud_data_dir: /library/owncloud/data
-
+owncloud_src_file: owncloud-7.0.4.tar.bz2

--- a/roles/xsce-admin/files/console/index.html
+++ b/roles/xsce-admin/files/console/index.html
@@ -134,6 +134,11 @@
 												</div>
 												<div class="checkbox">
 													<label>
+														<input type="checkbox" name="owncloud_enabled" id="owncloud_enabled">OwnCloud is a local server-based facility for sharing files, photos, contacts, calendars, etc.
+													</label>
+												</div>
+												<div class="checkbox">
+													<label>
 														<input type="checkbox" name="samba_enabled" id="samba_enabled">SAMBA provides Network File Sharing
 													</label>
 												</div>

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -10,7 +10,7 @@ xsce_dir: "{{ xsce_base }}/xsce"
 pip_packages_dir: "{{ xsce_base }}/pip-packages"
 yum_packages_dir: "{{ xsce_base }}/yum-packages"
 downloads_dir: "{{ xsce_base }}/downloads"
-xsce_download_url: download.unleashkids.org/xsce/downloads
+xsce_download_url: http://download.unleashkids.org/xsce/downloads
 
 #Configuration File(s)
 xsce_config_file: /etc/xsce/xsce.ini


### PR DESCRIPTION
incorporates the 'http://' into the download source parameter
installs owncloud from the tar file to get 7.0.4 even on fedora 18
adds owncloud_enabled to the console
adds a readme

tested on 64 bit vm and xo4
