### PR TITLE
use detected ansible_distribution_version

### DIFF
--- a/roles/1-prep/tasks/computed_vars.yml
+++ b/roles/1-prep/tasks/computed_vars.yml
@@ -86,5 +86,5 @@
 - name: Set mysqld service name to mysqld for fedora 18
   set_fact:
     mysql_service: mysqld
-  when: ansible_distribution_version == "18"
+  when: 'ansible_distribution_version == "18" or ansible_distribution_release == "based on Fedora 18"'
 

--- a/roles/1-prep/tasks/computed_vars.yml
+++ b/roles/1-prep/tasks/computed_vars.yml
@@ -85,6 +85,6 @@
     
 - name: Set mysqld service name to mysqld for fedora 18
   set_fact:
-    mysql_service: mysqld    
-  when: ansible_distribution_release == "based on Fedora 18"
-                  
+    mysql_service: mysqld
+  when: ansible_distribution_version == "18"
+


### PR DESCRIPTION
ansible_distribution_release can vary, a stock F18 install has "Spherical Cow" the above is specific to XOs only