### PR TITLE
Network with no gateway.

### DIFF
--- a/roles/gateway/tasks/dhcpd.yml
+++ b/roles/gateway/tasks/dhcpd.yml
@@ -31,3 +31,11 @@
   service: name=dhcpd 
            enabled=yes
            state=restarted
+  when: xsce_lan_iface != ""
+
+- name: Disable dhcpd service
+  service: name=dhcpd 
+           enabled=no
+           state=stopped
+  when: xsce_lan_iface == ""
+

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -47,7 +47,6 @@
     - gateway
 
 - include: wondershaper.yml
-  when: xsce_lan_iface != "" and xsce_wan_iface != "none"
   tags:
     - wondershaper
     - gateway

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -42,7 +42,6 @@
     - gateway
 
 - include: squid.yml
-  when: xsce_lan_iface != "" and xsce_wan_iface != "none"
   tags:
     - squid
     - gateway

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -37,7 +37,6 @@
   file: dest=/etc/sysconfig/xs_httpcache_on state=absent
 
 - include: dhcpd.yml
-  when: xsce_lan_iface != ""
   tags:
     - dhcpd
     - gateway

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -33,30 +33,41 @@
     - { src: "gateway/iptables.service" , dest: "/etc/systemd/system/iptables.service" }
     - { src: "gateway/xs-gen-iptables" , dest: "/usr/bin/xs-gen-iptables" }
 
+- name: delete proxy flag
+  file: dest=/etc/sysconfig/xs_httpcache_on state=absent
+
 - include: dhcpd.yml
-  when: 'xsce_lan_iface != ""' 
+  when: xsce_lan_iface != ""
   tags:
     - dhcpd
     - gateway
 
 - include: squid.yml
-  when: 'xsce_lan_iface != ""'
+  when: xsce_lan_iface != "" and xsce_wan_iface != "none"
   tags:
     - squid
     - gateway
 
 - include: wondershaper.yml
-  when: 'xsce_lan_iface != ""'
+  when: xsce_lan_iface != "" and xsce_wan_iface != "none"
   tags:
     - wondershaper
     - gateway
 
 - name: Run iptables 
   command: /etc/sysconfig/iptables-config
+  when: xsce_wan_iface != "none"
 
 - name: Enable iptables service 
   service: name=iptables
            enabled=yes
+  when: xsce_wan_iface != "none"
+
+- name: Disable iptables service 
+  service: name=iptables
+           enabled=no
+           state=stopped
+  when: xsce_wan_iface == "none"
 
 - name: Create gateway flag
   shell: echo 1 > /etc/sysconfig/olpc-scripts/setup.d/installed/gateway

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -54,18 +54,15 @@
 
 - name: Run iptables 
   command: /etc/sysconfig/iptables-config
-  when: xsce_wan_iface != "none"
 
 - name: Enable iptables service 
   service: name=iptables
            enabled=yes
-  when: xsce_wan_iface != "none"
 
 - name: Disable iptables service 
   service: name=iptables
            enabled=no
            state=stopped
-  when: xsce_wan_iface == "none"
 
 - name: Create gateway flag
   shell: echo 1 > /etc/sysconfig/olpc-scripts/setup.d/installed/gateway

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -59,11 +59,6 @@
   service: name=iptables
            enabled=yes
 
-- name: Disable iptables service 
-  service: name=iptables
-           enabled=no
-           state=stopped
-
 - name: Create gateway flag
   shell: echo 1 > /etc/sysconfig/olpc-scripts/setup.d/installed/gateway
          creates=/etc/sysconfig/olpc-scripts/setup.d/installed/gateway

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -57,6 +57,7 @@
 - name: Enable iptables service 
   service: name=iptables
            enabled=yes
+           state=restarted
 
 - name: Create gateway flag
   shell: echo 1 > /etc/sysconfig/olpc-scripts/setup.d/installed/gateway

--- a/roles/gateway/tasks/squid.yml
+++ b/roles/gateway/tasks/squid.yml
@@ -110,4 +110,4 @@
 - name: Create xs_httpcache flag
   shell: echo 1 > /etc/sysconfig/xs_httpcache_on
          creates=/etc/sysconfig/xs_httpcache_on
-  when: squid_enabled and xsce_wan_iface == "none"
+  when: squid_enabled and xsce_wan_iface != "none"

--- a/roles/gateway/tasks/squid.yml
+++ b/roles/gateway/tasks/squid.yml
@@ -110,4 +110,4 @@
 - name: Create xs_httpcache flag
   shell: echo 1 > /etc/sysconfig/xs_httpcache_on
          creates=/etc/sysconfig/xs_httpcache_on
-  when: squid_enabled and xsce_wan_iface != "none"
+  when: squid_enabled and xsce_lan_iface != ""

--- a/roles/gateway/tasks/squid.yml
+++ b/roles/gateway/tasks/squid.yml
@@ -110,4 +110,4 @@
 - name: Create xs_httpcache flag
   shell: echo 1 > /etc/sysconfig/xs_httpcache_on
          creates=/etc/sysconfig/xs_httpcache_on
-  when: squid_enabled and xsce_lan_iface != ""
+  when: squid_enabled and xsce_wan_iface != "none" and xsce_lan_iface != ""

--- a/roles/gateway/tasks/squid.yml
+++ b/roles/gateway/tasks/squid.yml
@@ -87,25 +87,25 @@
   service: name=dansguardian
            enabled=yes
            state=restarted
-  when: dansguardian_enabled and xsce_wan_iface != "none"
+  when: dansguardian_enabled and xsce_wan_iface != "none" and xsce_lan_iface != ""
 
 - name: Disable dansguardian
   service: name=dansguardian
            enabled=no
            state=stopped
-  when: not dansguardian_enabled or xsce_wan_iface == "none"
+  when: not dansguardian_enabled or xsce_wan_iface == "none" or xsce_lan_iface == ""
  
 - name: Enable squid service
   service: name=squid
            enabled=yes
            state=restarted
-  when: squid_enabled and xsce_wan_iface != "none"
+  when: squid_enabled and xsce_wan_iface != "none" and xsce_lan_iface != ""
 
 - name: Disable squid service
   service: name=squid
            enabled=no
            state=stopped
-  when: not squid_enabled or xsce_wan_iface == "none"
+  when: not squid_enabled or xsce_wan_iface == "none" or xsce_lan_iface == ""
 
 - name: Create xs_httpcache flag
   shell: echo 1 > /etc/sysconfig/xs_httpcache_on

--- a/roles/gateway/tasks/squid.yml
+++ b/roles/gateway/tasks/squid.yml
@@ -87,19 +87,27 @@
   service: name=dansguardian
            enabled=yes
            state=restarted
-  when: dansguardian_enabled
+  when: dansguardian_enabled and xsce_wan_iface != "none"
 
 - name: Disable dansguardian
   service: name=dansguardian
            enabled=no
            state=stopped
-  when: not dansguardian_enabled
+  when: not dansguardian_enabled or xsce_wan_iface == "none"
  
-- name: Create xs_httpcache flag
-  shell: echo 1 > /etc/sysconfig/xs_httpcache_on
-         creates=/etc/sysconfig/xs_httpcache_on
-
-- name: Start squid service
+- name: Enable squid service
   service: name=squid
            enabled=yes
            state=restarted
+  when: squid_enabled and xsce_wan_iface != "none"
+
+- name: Disable squid service
+  service: name=squid
+           enabled=no
+           state=stopped
+  when: not squid_enabled or xsce_wan_iface == "none"
+
+- name: Create xs_httpcache flag
+  shell: echo 1 > /etc/sysconfig/xs_httpcache_on
+         creates=/etc/sysconfig/xs_httpcache_on
+  when: squid_enabled and xsce_wan_iface == "none"

--- a/roles/gateway/tasks/wondershaper.yml
+++ b/roles/gateway/tasks/wondershaper.yml
@@ -34,7 +34,14 @@
         group=root
         state=link
 
+- name: disable wondershaper service
+  service: name=wondershaper
+           enabled=no
+           state=stopped
+  when: xsce_wan_iface == "none" or xsce_lan_iface != ""
+
 - name: enable wondershaper service
   service: name=wondershaper
            enabled=yes
            state=restarted
+  when: xsce_wan_iface != "none" and xsce_lan_iface != ""

--- a/roles/gateway/templates/gateway/xs-gen-iptables
+++ b/roles/gateway/templates/gateway/xs-gen-iptables
@@ -1,22 +1,26 @@
 #!/bin/bash -x
 IPTABLES=/usr/sbin/iptables
-#wan="eth0"
-#lan="eth1"
-#LANIF=`route -n | gawk '/172.18.96/{ print $8 }'`
-#WANIF=`route -n | gawk '/UG/{ print $8 }'`
 LANIF=`cat /etc/sysconfig/xs_lan_device`
 WANIF=`cat /etc/sysconfig/xs_wan_device`
 
-gw_block_https={{ gw_block_https }}
+clear_fw() {
+    $IPTABLES -F
+    $IPTABLES -t nat -F
+    $IPTABLES -X
+    exit 0
+}
 
-if [  "x$WANIF" == "x" ]; then
-    exit 1
+if [  "x$WANIF" == "xnone" ]; then
+    clear_fw
 fi
 if [  "x$LANIF" == "x" ]; then
-    exit 1
+    clear_fw
 fi
-        lan=$LANIF
-        wan=$WANIF
+
+gw_block_https={{ gw_block_https }}
+
+lan=$LANIF
+wan=$WANIF
 echo "Lan is $lan and WAN is $wan"
 #
 # delete all existing rules.

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,21 +1,3 @@
-- name: Discover LAN iface
-  shell: "/sbin/ip link show  | grep -v -e DOWN -e lo -e tun -e {{ ansible_default_ipv4.alias }}| grep mtu | gawk -F: '{print $2}' |  tr -d ' '  | head -n1 "
-  register: discovered_lan
-  
-  changed_when: false
-  tags:
-    - network-discover
-    - gateway
-    - dhcpd
-    - ajenti
-    - wondershaper
-    - core
-    - xo
-    - download
-    - services
-    - squid
-
-
 - name: Set xsce configured lan fact
   set_fact:
      xsce_lan_iface: "{{ xsce_lan_iface }}"
@@ -32,27 +14,10 @@
     - services
     - squid
 
-- name: Set xsce discovered lan fact
-  set_fact:
-     xsce_lan_iface: "{{ discovered_lan.stdout }}"
-  when: 'xsce_lan_iface == "auto"  and discovered_lan.stdout  != ""'
-  tags:
-    - network-discover
-    - gateway
-    - dhcpd
-    - ajenti
-    - wondershaper
-    - core
-    - xo
-    - download
-    - services
-    - squid
-
-
 - name: No LAN configured - Appliance mode
   set_fact:
      xsce_lan_iface: ""
-  when: 'xsce_lan_iface == "none" or (discovered_lan.stdout == "" and xsce_lan_iface == "auto" )'
+  when: 'xsce_lan_iface == "none"'
   tags:
     - network-discover
     - gateway
@@ -65,6 +30,39 @@
     - services
     - squid
 
+- name: Discover LAN iface
+  shell: "/sbin/ip link show  | grep -v -e DOWN -e lo -e tun -e {{ ansible_default_ipv4.alias }}| grep mtu | gawk -F: '{print $2}' |  tr -d ' '  | head -n1 "
+  register: discovered_lan
+  
+  changed_when: false
+  tags:
+    - network-discover
+    - gateway
+    - dhcpd
+    - ajenti
+    - wondershaper
+    - core
+    - xo
+    - download
+    - services
+    - squid
+  when: 'xsce_lan_iface == "auto"'
+
+- name: Set xsce discovered lan fact
+  set_fact:
+     xsce_lan_iface: "{{ discovered_lan.stdout }}"
+  when: 'xsce_lan_iface == "auto"'
+  tags:
+    - network-discover
+    - gateway
+    - dhcpd
+    - ajenti
+    - wondershaper
+    - core
+    - xo
+    - download
+    - services
+    - squid
 
 - name: Create xs network flags
   template: backup=yes

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -33,8 +33,8 @@
 - name: Discover LAN iface
   shell: "/sbin/ip link show  | grep -v -e DOWN -e lo -e tun -e {{ ansible_default_ipv4.alias }}| grep mtu | gawk -F: '{print $2}' |  tr -d ' '  | head -n1 "
   register: discovered_lan
-  
   changed_when: false
+  when: 'xsce_lan_iface == "auto"'
   tags:
     - network-discover
     - gateway
@@ -46,7 +46,6 @@
     - download
     - services
     - squid
-  when: 'xsce_lan_iface == "auto"'
 
 - name: Set xsce discovered lan fact
   set_fact:


### PR DESCRIPTION
Without a gateway present ansible crashes hard at:
TASK: [network | Discover LAN iface] ****************************************** 
fatal: [127.0.0.1] => One or more undefined variables: 'dict object' has no attribute 'alias'

FATAL: all hosts have already failed -- aborting

PLAY RECAP ******************************************************************** 
           to retry, use: --limit @/root/xsce-base.retry

127.0.0.1                  : ok=42   changed=7    unreachable=1    failed=0   

Patches 1 & 2 reorder the setting of xsce_lan_iface to avoid the running of shell code if xsce_lan_iface declared in local_vars.
Patch 3 allows the skipping of the of unneeded gateway play-books, and disables iptables when none is declared for xsce_wan_iface  in local_vars. The disabling of the services is not addressed, just bypassing those playbooks to run to success.  Those unneeded services can be disabled in the GUI later if needed
