### PR TITLE
BUGFIX gateway services

### DIFF
--- a/roles/gateway/tasks/dhcpd.yml
+++ b/roles/gateway/tasks/dhcpd.yml
@@ -27,7 +27,14 @@
         mode=0644
         state=file
 
+- name: Disable dhcpd service
+  service: name=dhcpd 
+           enabled=no
+           state=stopped
+  when: not dhcpd_enabled
+
 - name: Enable dhcpd service
   service: name=dhcpd 
            enabled=yes
            state=restarted
+  when: dhcpd_enabled

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -34,19 +34,16 @@
     - { src: "gateway/xs-gen-iptables" , dest: "/usr/bin/xs-gen-iptables" }
 
 - include: dhcpd.yml
-  when: 'xsce_lan_iface != ""' 
   tags:
     - dhcpd
     - gateway
 
 - include: squid.yml
-  when: 'xsce_lan_iface != ""'
   tags:
     - squid
     - gateway
 
 - include: wondershaper.yml
-  when: 'xsce_lan_iface != ""'
   tags:
     - wondershaper
     - gateway

--- a/roles/gateway/tasks/squid.yml
+++ b/roles/gateway/tasks/squid.yml
@@ -98,6 +98,7 @@
 - name: Create xs_httpcache flag
   shell: echo 1 > /etc/sysconfig/xs_httpcache_on
          creates=/etc/sysconfig/xs_httpcache_on
+  when: squid_enabled
 
 - name: Enable squid service
   service: name=squid
@@ -110,3 +111,9 @@
            enabled=no
            state=stopped
   when: not squid_enabled
+
+- name: Remove xs_httpcache flag
+  file: path=/etc/sysconfig/xs_httpcache_on
+        state=absent
+  when: not squid_enabled
+

--- a/roles/gateway/tasks/squid.yml
+++ b/roles/gateway/tasks/squid.yml
@@ -99,7 +99,14 @@
   shell: echo 1 > /etc/sysconfig/xs_httpcache_on
          creates=/etc/sysconfig/xs_httpcache_on
 
-- name: Start squid service
+- name: Enable squid service
   service: name=squid
            enabled=yes
            state=restarted
+  when: squid_enabled
+
+- name: Disable squid service
+  service: name=squid
+           enabled=no
+           state=stopped
+  when: not squid_enabled

--- a/roles/gateway/tasks/wondershaper.yml
+++ b/roles/gateway/tasks/wondershaper.yml
@@ -42,6 +42,6 @@
 
 - name: Disable wondershaper service
   service: name=wondershaper
-           enabled=yes
-           state=restarted
+           enabled=no
+           state=stopped
   when: not wondershaper_enabled

--- a/roles/gateway/tasks/wondershaper.yml
+++ b/roles/gateway/tasks/wondershaper.yml
@@ -34,7 +34,14 @@
         group=root
         state=link
 
-- name: enable wondershaper service
+- name: Enable wondershaper service
   service: name=wondershaper
            enabled=yes
            state=restarted
+  when: wondershaper_enabled
+
+- name: Disable wondershaper service
+  service: name=wondershaper
+           enabled=yes
+           state=restarted
+  when: not wondershaper_enabled

--- a/roles/network/tasks/named.yml
+++ b/roles/network/tasks/named.yml
@@ -50,3 +50,10 @@
   service: name=named
            enabled=yes
            state=restarted
+  when: named_enabled
+
+- name: Disable named service
+  service: name=named
+           enabled=no
+           state=stopped
+  when: not named_enabled

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -61,12 +61,29 @@ xsce_lan_iface: auto
 
 # 3-BASE
 
+# dhcpd
+dhcpd_install: True
+dhcpd_enabled: True
+
+# dansguardian
+dansguardian_install: True
+dansguardian_enabled: True
+
+# squid
+squid_install: True
+squid_enabled: True
+
+# wondershaper
+wondershaper_install: True
+wondershaper_enabled: True
+
 #Gateway and Filters
 xsce_gateway_enabled: True
-squid_enabled: True
-dansguardian_enabled: True
+
+# optional part
 gw_squid_whitelist: False
 gw_block_https: False
+
 
 # 4-SERVER-OPTIONS
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -65,6 +65,10 @@ xsce_lan_iface: auto
 dhcpd_install: True
 dhcpd_enabled: True
 
+# named
+named_install: True
+named_enabled: True
+
 # dansguardian
 dansguardian_install: True
 dansguardian_enabled: True


### PR DESCRIPTION
While working on the network revamp I noticed some of the gateway services don't have *_enabled stanzas, leaving no future way of disabling of these service from within ansible. These are optionally installed and configured currently only at install time. Remove the run-time LAN condition allowing playbooks to be accessed anytime, this allows the services to respect any *_enabled variables passed. This will allow installation of gateway services while not having a LAN present at installation time.