### PR TITLE
BUGFIX #210

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,25 +1,8 @@
-- name: Discover LAN iface
-  shell: "/sbin/ip link show  | grep -v -e DOWN -e lo -e tun -e {{ ansible_default_ipv4.alias }}| grep mtu | gawk -F: '{print $2}' |  tr -d ' '  | head -n1 "
-  register: discovered_lan
-  
-  changed_when: false
-  tags:
-    - network-discover
-    - gateway
-    - dhcpd
-    - ajenti
-    - wondershaper
-    - core
-    - xo
-    - download
-    - services
-    - squid
-
-
-- name: Set xsce configured lan fact
+# WAN
+- name: Set user configured wan fact
   set_fact:
-     xsce_lan_iface: "{{ xsce_lan_iface }}"
-  when: 'xsce_lan_iface != "auto" and xsce_lan_iface != "none" '
+    xsce_wan_iface: "{{ xsce_wan_iface }}"
+  when: 'xsce_wan_iface != "auto" or xsce_wan_iface != ""'
   tags:
     - network-discover
     - gateway
@@ -31,11 +14,50 @@
     - download
     - services
     - squid
+
+- name: Found xsce_wan_iface set to none or no detected gateway
+  set_fact:
+  xsce_wan_iface: "none"
+  when: 'xsce_wan_iface == "none" or not ansible_default_ipv4.gateway is defined'
+  tags:
+    - network-discover
+    - gateway
+    - dhcpd
+    - ajenti
+    - wondershaper
+    - core
+    - xo
+    - download
+    - services
+    - squid
+
+- name: Found gateway
+  set_fact:
+    xsce_wan_iface: "{{ ansible_default_ipv4.alias }}"
+  when: 'xsce_wan_iface == "auto" and ansible_default_ipv4.gateway is defined'
+  tags:
+    - network-discover
+    - gateway
+    - dhcpd
+    - ajenti
+    - wondershaper
+    - core
+    - xo
+    - download
+    - services
+    - squid
+
+# LAN - Order is: <nic> none auto
+- name: Discover LAN iface
+  shell: "/sbin/ip link show | grep -v -e DOWN -e lo -e tun -e {{ xsce_wan_iface }}| grep mtu | gawk -F: '{print $2}' | tr -d ' ' | head -n1 "
+  register: discovered_lan
+  ignore_errors: True
+  changed_when: false
 
 - name: Set xsce discovered lan fact
   set_fact:
-     xsce_lan_iface: "{{ discovered_lan.stdout }}"
-  when: 'xsce_lan_iface == "auto"  and discovered_lan.stdout  != ""'
+    xsce_lan_iface: "{{ discovered_lan.stdout }}"
+  when: 'xsce_lan_iface == "auto" and discovered_lan is defined'
   tags:
     - network-discover
     - gateway
@@ -47,12 +69,11 @@
     - download
     - services
     - squid
-
 
 - name: No LAN configured - Appliance mode
   set_fact:
-     xsce_lan_iface: ""
-  when: 'xsce_lan_iface == "none" or (discovered_lan.stdout == "" and xsce_lan_iface == "auto" )'
+     xsce_lan_iface: "none"
+  when: 'xsce_lan_iface == "none" or not discovered_lan is definded'
   tags:
     - network-discover
     - gateway
@@ -64,7 +85,6 @@
     - download
     - services
     - squid
-
 
 - name: Create xs network flags
   template: backup=yes
@@ -77,7 +97,6 @@
     - xs_domain_name
   tags:
     - network-discover
-
 
 - name: Configure /etc/sysconfig/network
   template: backup=yes

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -73,7 +73,7 @@
 - name: No LAN configured - Appliance mode
   set_fact:
      xsce_lan_iface: "none"
-  when: 'xsce_lan_iface == "none" or not discovered_lan is definded'
+  when: 'xsce_lan_iface == "none" or not discovered_lan us defined'
   tags:
     - network-discover
     - gateway

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -73,7 +73,7 @@
 - name: No LAN configured - Appliance mode
   set_fact:
      xsce_lan_iface: "none"
-  when: 'xsce_lan_iface == "none" or not discovered_lan us defined'
+  when: 'xsce_lan_iface == "none" or not discovered_lan is defined'
   tags:
     - network-discover
     - gateway

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Found xsce_wan_iface set to none or no detected gateway
   set_fact:
-  xsce_wan_iface: "none"
+    xsce_wan_iface: "none"
   when: 'xsce_wan_iface == "none" or not ansible_default_ipv4.gateway is defined'
   tags:
     - network-discover

--- a/roles/network/templates/xs_lan_device.j2
+++ b/roles/network/templates/xs_lan_device.j2
@@ -1,5 +1,3 @@
-{% if xsce_lan_iface != "" %}
+{% if xsce_lan_iface != "none" %}
 {{ xsce_lan_iface }}
-{% else %}
-{{ xsce_wan_iface }}
 {% endif %}

--- a/roles/network/templates/xs_wan_device.j2
+++ b/roles/network/templates/xs_wan_device.j2
@@ -1,1 +1,4 @@
+{% if xsce_wan_iface != "none" %}
 {{ xsce_wan_iface }}
+{% endif %}
+

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -44,7 +44,7 @@ lan_ip: 172.18.96.1
 lan_netmask: 255.255.224.0
 
 #Read docs/NETWORKING.rst
-xsce_wan_iface: "{{ ansible_default_ipv4.interface }}"
+xsce_wan_iface: auto
 xsce_lan_iface: auto
 
 # Parameters by Aggregate Roles


### PR DESCRIPTION
Backport from #214 for #210 for better readability. grep -e doesn't like blanks or {} so use none instead then set to blank