### PR TITLE
dhcpd error

### DIFF
--- a/roles/3-base-server/meta/main.yml
+++ b/roles/3-base-server/meta/main.yml
@@ -1,6 +1,6 @@
 dependencies:
-   - { role: network, tags: ['base','network'] }
    - { role: gateway, tags: ['base','gateway'] }
+   - { role: network, tags: ['base','network'] }
    - { role: httpd, tags: ['services','httpd','base'] }
    - { role: postgresql, tags: ['services','postgresql','base'] }
    - { role: authserver,  tags: ['services','authserver','base'] }   

--- a/roles/gateway/tasks/dhcpd.yml
+++ b/roles/gateway/tasks/dhcpd.yml
@@ -33,6 +33,7 @@
            state=stopped
   when: not dhcpd_enabled
 
+# service is started via NM dispatcher
 - name: Enable dhcpd service
   service: name=dhcpd 
            enabled=yes

--- a/roles/gateway/tasks/dhcpd.yml
+++ b/roles/gateway/tasks/dhcpd.yml
@@ -36,5 +36,4 @@
 - name: Enable dhcpd service
   service: name=dhcpd 
            enabled=yes
-           state=restarted
   when: dhcpd_enabled

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,3 +1,8 @@
+- include: named.yml
+  tags:
+    - named
+    - network
+
 - name: Create xs network flags
   template: backup=yes
             src={{ item }}.j2
@@ -66,8 +71,3 @@
            enabled=yes
            state=started
 - debug:  msg="hopefully now NM is restarted"
-
-- include: named.yml
-  tags:
-    - named
-    - network


### PR DESCRIPTION
When the network is restarted the provided NM's dispatcher script restarts dhcpd when enabled in systemd but /etc/sysconfig/dhcpd might list stale data is one cause of the error noted in #222. Suppress this by restarting the network last there by refreshing the data and setting dis(en)abled before the script fires off. Remove the unconditional restart of dhcpd during installation just enable the service because the installation might be in single interface mode at that point, would be the other cause of the error noted.