### PR TITLE
RFC Tagging

### DIFF
--- a/roles/1-prep/tasks/main.yml
+++ b/roles/1-prep/tasks/main.yml
@@ -1,9 +1,18 @@
 - include: prep.yml
+  tags:
+    - prep
+
 - include: computed_vars.yml
+  tags:
+    - platform
+
 - include: computed_network.yml
+  tags:
+    - platform
            
 # Put conditional includes for platforms here
 - include: xo.yml
   when: xo_model != "none"
   tags:
+    - platform
     - xo

--- a/roles/2-common/tasks/main.yml
+++ b/roles/2-common/tasks/main.yml
@@ -2,13 +2,25 @@
   when: ansible_selinux["status"] != "disabled"
   tags:
     - download
+    - common
     
 - include: prelim.yml
+  tags:
+    - prep
 
 - include: yum.yml 
   tags:
+    - common
     - download
 
 - include: chrony.yml
+  tags:
+    - common
+
 - include: avahi.yml
+  tags:
+    - common
+
 - include: sysctl.yml
+  tags:
+    - common

--- a/runtags
+++ b/runtags
@@ -22,7 +22,7 @@ found="N"
 
 for tag in $tags
 do
-  if [ "$tag" == "prep" ]
+  if [ "$tag" == "platform" ]
   then
     found="Y"
   fi
@@ -35,7 +35,7 @@ taglist=$1
 
 if [ "$found" == "N" ]
 then
-  taglist="prep,"$taglist
+  taglist="platform,"$taglist
 fi
 
 # script to run a specific tag in the current playbook

--- a/xsce-base.yml
+++ b/xsce-base.yml
@@ -8,5 +8,5 @@
 
   roles:
       - { role: 1-prep, tags: ['prep','platform','base'] }
-      - { role: 2-common, tags: ['common','base'] }
+      - { role: 2-common, tags: ['prep','common','base'] }
       - { role: 3-base-server, tags: ['base'] }

--- a/xsce-from-console.yml
+++ b/xsce-from-console.yml
@@ -8,7 +8,7 @@
   - /etc/xsce/config_vars.yml
 
   roles:
-      - { role: 1-prep, tags: ['prep','platform','base'] }
+      - { role: 1-prep, tags: ['platform','base'] }
       - { role: 2-common, tags: ['common','base'] }
       - { role: 3-base-server, tags: ['base'] }
       - { role: 4-server-options, tags: ['options'] }

--- a/xsce.yml
+++ b/xsce.yml
@@ -8,7 +8,7 @@
 
   roles:
       - { role: 1-prep, tags: ['prep','platform','base'] }
-      - { role: 2-common, tags: ['common','base'] }
+      - { role: 2-common, tags: ['prep','common','base'] }
       - { role: 3-base-server, tags: ['base'] }
       - { role: 4-server-options, tags: ['options'] }
       - { role: 5-xo-services, tags: ['xo-services'] }


### PR DESCRIPTION
This allows skipping of prep.yml and prelim.yml after the first run of ansible, computed_* facts are still done under the platform tag.