### PR TITLE
improvements for iptables & avahi

### DIFF
--- a/roles/2-common/tasks/avahi.yml
+++ b/roles/2-common/tasks/avahi.yml
@@ -16,8 +16,16 @@
             owner=avahi
             group=avahi
             mode=640
+  when: 'gui_wan == "True"'
   tags:     avahi
-           
+
+- name set ssh port for avahi
+  lineinfile: dest=/etc/avahi/services/ssh.service
+              regexp='^<port>'
+              line='<port>{{ssh_port}}</port>'
+              state=present
+  tags:     avahi
+
 - name: Enable avahi service
   service: name=avahi-daemon
            enabled=yes

--- a/roles/2-common/tasks/avahi.yml
+++ b/roles/2-common/tasks/avahi.yml
@@ -19,7 +19,7 @@
   when: 'gui_wan == "True"'
   tags:     avahi
 
-- name set ssh port for avahi
+- name: set ssh port for avahi
   lineinfile: dest=/etc/avahi/services/ssh.service
               regexp='^<port>'
               line='<port>{{ssh_port}}</port>'

--- a/roles/2-common/templates/schoolserver.service
+++ b/roles/2-common/templates/schoolserver.service
@@ -1,9 +1,17 @@
 <?xml version="1.0" standalone='no'?><!--*-nxml-*-->
 <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
 <service-group>
-<name replace-wildcards="yes">School Server Idmgr Service at %h </name>
+<name replace-wildcards="yes">School Server Service at %h </name>
 <service>
-<type>_idmgr._tcp</type>
-<port>8080</port>
+<type>_ssh._tcp</type>
+<port>{{ssh_port}}</port>
 </service>
+
+{% if gui_wan == "True" %}
+<service>
+<type>_https._tcp</type>
+<port>{{gui_port}}</port>
+</service>
+{% endif %}
+
 </service-group>

--- a/roles/2-common/templates/schoolserver.service
+++ b/roles/2-common/templates/schoolserver.service
@@ -1,17 +1,9 @@
 <?xml version="1.0" standalone='no'?><!--*-nxml-*-->
 <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
 <service-group>
-<name replace-wildcards="yes">School Server Service at %h </name>
-<service>
-<type>_ssh._tcp</type>
-<port>{{ssh_port}}</port>
-</service>
-
-{% if gui_wan == "True" %}
+<name replace-wildcards="yes">MGMT console at %h </name>
 <service>
 <type>_https._tcp</type>
 <port>{{gui_port}}</port>
 </service>
-{% endif %}
-
 </service-group>

--- a/roles/gateway/templates/gateway/iptables-xs.j2
+++ b/roles/gateway/templates/gateway/iptables-xs.j2
@@ -16,7 +16,7 @@ COMMIT
 -A INPUT -i lo -j ACCEPT
 
 # Allow ssh access on all interfaces
--A INPUT -m state --state NEW -m tcp -p tcp --dport 22 -j ACCEPT
+-A INPUT -m state --state NEW -m tcp -p tcp --dport {{ ssh_port }} -j ACCEPT
 
 # Allow all LAN services
 -A INPUT ! -i {{xsce_wan_iface}} -m state --state NEW -j ACCEPT

--- a/roles/gateway/templates/gateway/iptables-xs.j2
+++ b/roles/gateway/templates/gateway/iptables-xs.j2
@@ -5,6 +5,10 @@
 {% if squid_enabled == "True" %}
 -t nat  -A PREROUTING -i $lan -p tcp --dport 80 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:3128
 {% endif %}
+{% if block_DNS == "True" %}
+-t nat  -A PREROUTING -i $lan -p tcp --dport 53 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:53
+-t nat  -A PREROUTING -i $lan -p udp --dport 53 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:53
+{% endif %}
 {% if xsce_gateway_enabled == "True" %}
 -A POSTROUTING -o {{xsce_wan_iface}} -j MASQUERADE
 {% endif %}

--- a/roles/gateway/templates/gateway/iptables-xs.j2
+++ b/roles/gateway/templates/gateway/iptables-xs.j2
@@ -5,7 +5,9 @@
 {% if squid_enabled == "True" %}
 -t nat  -A PREROUTING -i $lan -p tcp --dport 80 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:3128
 {% endif %}
+{% if xsce_gateway_enabled == "True" %}
 -A POSTROUTING -o {{xsce_wan_iface}} -j MASQUERADE
+{% endif %}
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/roles/gateway/templates/gateway/iptables-xs.j2
+++ b/roles/gateway/templates/gateway/iptables-xs.j2
@@ -18,6 +18,11 @@ COMMIT
 # Allow ssh access on all interfaces
 -A INPUT -m state --state NEW -m tcp -p tcp --dport {{ ssh_port }} -j ACCEPT
 
+# Allow gui access on all interfaces
+{% if gui_wan == "True" %}
+-A INPUT -m state --state NEW -m tcp -p tcp --dport {{ gui_port }} -j ACCEPT
+{% endif %}
+
 # Allow all LAN services
 -A INPUT ! -i {{xsce_wan_iface}} -m state --state NEW -j ACCEPT
 

--- a/roles/gateway/templates/gateway/xs-gen-iptables
+++ b/roles/gateway/templates/gateway/xs-gen-iptables
@@ -42,7 +42,7 @@ $IPTABLES -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 $IPTABLES -A INPUT -m state --state NEW -i  $lan -j ACCEPT
 
 # Allow mDNS 
-$IPTABLES -A INPUT -p udp --dport 5353 -d 224.0.0.251 -j ACCEPT
+$IPTABLES -A INPUT -p udp --dport 5353 -j ACCEPT
 
 #when run as gateway 
 $IPTABLES -A INPUT -p tcp --dport {{ ssh_port }} -m state --state NEW -i $wan -j ACCEPT

--- a/roles/gateway/templates/gateway/xs-gen-iptables
+++ b/roles/gateway/templates/gateway/xs-gen-iptables
@@ -47,6 +47,10 @@ $IPTABLES -A INPUT -p udp --dport 5353 -d 224.0.0.251 -j ACCEPT
 #when run as gateway 
 $IPTABLES -A INPUT -p tcp --dport {{ ssh_port }} -m state --state NEW -i $wan -j ACCEPT
 
+{% if gui_wan == "True" %}
+$IPTABLES -A INPUT -p tcp --dport {{ gui_port }} -m state --state NEW -i $wan -j ACCEPT
+{% endif %}
+
 $IPTABLES -A POSTROUTING -t nat -o $wan -j MASQUERADE
 $IPTABLES -A FORWARD -i $wan -o $lan -m state --state ESTABLISHED,RELATED -j ACCEPT
 

--- a/roles/gateway/templates/gateway/xs-gen-iptables
+++ b/roles/gateway/templates/gateway/xs-gen-iptables
@@ -21,8 +21,10 @@ fi
 lan=$LANIF
 wan=$WANIF
 
-# Good thing we replace this file should be treated like squid below
 gw_block_https={{ gw_block_https }}
+ssh_port={{ ssh_port }}
+gui_wan={{ gui_wan }}
+gui_port={{ gui_port }}
 
 echo "Lan is $lan and WAN is $wan"
 #
@@ -45,17 +47,17 @@ $IPTABLES -A INPUT -m state --state NEW -i  $lan -j ACCEPT
 $IPTABLES -A INPUT -p udp --dport 5353 -j ACCEPT
 
 #when run as gateway 
-$IPTABLES -A INPUT -p tcp --dport {{ ssh_port }} -m state --state NEW -i $wan -j ACCEPT
+$IPTABLES -A INPUT -p tcp --dport $ssh_port -m state --state NEW -i $wan -j ACCEPT
 
-{% if gui_wan == "True" %}
-$IPTABLES -A INPUT -p tcp --dport {{ gui_port }} -m state --state NEW -i $wan -j ACCEPT
-{% endif %}
+if [ "$gui_wan" == "True" ]; then
+    $IPTABLES -A INPUT -p tcp --dport $gui_port -m state --state NEW -i $wan -j ACCEPT
+fi
 
 $IPTABLES -A FORWARD -i $wan -o $lan -m state --state ESTABLISHED,RELATED -j ACCEPT
 
-{% if xsce_gateway_enabled == "True" %}
-$IPTABLES -A POSTROUTING -t nat -o $wan -j MASQUERADE
-{% endif %}
+if [ "$xsce_gateway_enabled" == "True" ]; then
+    $IPTABLES -A POSTROUTING -t nat -o $wan -j MASQUERADE
+fi
 
 #Block https traffic except if directed at server
 if [  "$gw_block_https" == "True" ]; then    
@@ -69,10 +71,10 @@ $IPTABLES -A FORWARD -i $lan -o $wan -j ACCEPT
 $IPTABLES -A FORWARD -i $wan -o $lan -j DROP
 $IPTABLES -A INPUT -i $wan -j DROP
 
-{% if block_DNS == "True" %}
-$IPTABLES -t nat  -A PREROUTING -i $lan -p tcp --dport 53 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:53
-$IPTABLES -t nat  -A PREROUTING -i $lan -p udp --dport 53 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:53
-{% endif %}
+if [ "$block_DNS" == "True" ];then
+    $IPTABLES -t nat  -A PREROUTING -i $lan -p tcp --dport 53 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:53
+    $IPTABLES -t nat  -A PREROUTING -i $lan -p udp --dport 53 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:53
+fi
 
 if [ -f /etc/sysconfig/xs_httpcache_on ]; then
     $IPTABLES  -t nat  -A PREROUTING -i $lan -p tcp --dport 80 ! -d 172.18.96.1 -j DNAT --to 172.18.96.1:3128

--- a/roles/gateway/templates/gateway/xs-gen-iptables
+++ b/roles/gateway/templates/gateway/xs-gen-iptables
@@ -45,7 +45,7 @@ $IPTABLES -A INPUT -m state --state NEW -i  $lan -j ACCEPT
 $IPTABLES -A INPUT -p udp --dport 5353 -d 224.0.0.251 -j ACCEPT
 
 #when run as gateway 
-$IPTABLES -A INPUT -p tcp --dport ssh -m state --state NEW -i $wan -j ACCEPT
+$IPTABLES -A INPUT -p tcp --dport {{ ssh_port }} -m state --state NEW -i $wan -j ACCEPT
 
 $IPTABLES -A POSTROUTING -t nat -o $wan -j MASQUERADE
 $IPTABLES -A FORWARD -i $wan -o $lan -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/roles/gateway/templates/gateway/xs-gen-iptables
+++ b/roles/gateway/templates/gateway/xs-gen-iptables
@@ -51,8 +51,11 @@ $IPTABLES -A INPUT -p tcp --dport {{ ssh_port }} -m state --state NEW -i $wan -j
 $IPTABLES -A INPUT -p tcp --dport {{ gui_port }} -m state --state NEW -i $wan -j ACCEPT
 {% endif %}
 
-$IPTABLES -A POSTROUTING -t nat -o $wan -j MASQUERADE
 $IPTABLES -A FORWARD -i $wan -o $lan -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+{% if xsce_gateway_enabled == "True" %}
+$IPTABLES -A POSTROUTING -t nat -o $wan -j MASQUERADE
+{% endif %}
 
 #Block https traffic except if directed at server
 if [  "$gw_block_https" == "True" ]; then    

--- a/roles/gateway/templates/gateway/xs-gen-iptables
+++ b/roles/gateway/templates/gateway/xs-gen-iptables
@@ -69,6 +69,11 @@ $IPTABLES -A FORWARD -i $lan -o $wan -j ACCEPT
 $IPTABLES -A FORWARD -i $wan -o $lan -j DROP
 $IPTABLES -A INPUT -i $wan -j DROP
 
+{% if block_DNS == "True" %}
+$IPTABLES -t nat  -A PREROUTING -i $lan -p tcp --dport 53 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:53
+$IPTABLES -t nat  -A PREROUTING -i $lan -p udp --dport 53 ! -d {{lan_ip}} -j DNAT --to {{lan_ip}}:53
+{% endif %}
+
 if [ -f /etc/sysconfig/xs_httpcache_on ]; then
     $IPTABLES  -t nat  -A PREROUTING -i $lan -p tcp --dport 80 ! -d 172.18.96.1 -j DNAT --to 172.18.96.1:3128
 fi

--- a/roles/gateway/templates/squid/squid-xs.conf.j2
+++ b/roles/gateway/templates/squid/squid-xs.conf.j2
@@ -5,7 +5,7 @@
 #  Network Interface
 
 {% if dansguardian_enabled %}
-http_port 0.0.0.0:3130 
+http_port 127.0.0.1:3130 
 {% else %}
 http_port 0.0.0.0:3128 transparent
 {% endif %}

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -46,6 +46,7 @@ lan_netmask: 255.255.224.0
 #Read docs/NETWORKING.rst
 xsce_lan_enabled: True
 xsce_wan_enabled: True
+ssh_port: 22
 
 #intended for developers
 user_lan_iface: auto

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -47,6 +47,8 @@ lan_netmask: 255.255.224.0
 xsce_lan_enabled: True
 xsce_wan_enabled: True
 ssh_port: 22
+gui_wan: True
+gui_port: 443
 
 #intended for developers
 user_lan_iface: auto

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -76,6 +76,7 @@ dhcpd_enabled: True
 # named
 named_install: True
 named_enabled: True
+block_DNS: False
 
 # dansguardian
 dansguardian_install: True


### PR DESCRIPTION
1. allow user to use other than stock ssh port(actual port change in sshd is not covered)
2. allow access to https for console
3. allow access for avahi on all interfaces
4. use preexisting flag to en/disable forwarding
5. advertise ssh and https services with avahi
6. lock down squid when dansguardian is active
7. optionally intercept DNS bound for the web.

Note: tested xs-gen-iptables routine, other template matches but not tested.
