### PR TITLE
Pathagar: update version of django-sendfile

### DIFF
--- a/roles/pathagar/tasks/main.yml
+++ b/roles/pathagar/tasks/main.yml
@@ -52,7 +52,7 @@
   with_items:
     - Django==1.4.5
     - django-tagging==0.3.1
-    - django-sendfile==0.3.0
+    - django-sendfile==0.3.6
     - django-taggit==0.10
   tags:
     - download


### PR DESCRIPTION
The version 0.3.0 gives a error trying to install, version 0.3.6 works ok.