### PR TITLE
Pathagar: update version of django-sendfile ans add mod_wsgi dependency

### DIFF
--- a/roles/pathagar/tasks/main.yml
+++ b/roles/pathagar/tasks/main.yml
@@ -8,6 +8,7 @@
     - python-virtualenv
     - python-pip
     - python-psycopg2
+    - mod_wsgi
   tags:
     - download
 
@@ -40,7 +41,7 @@
   with_items:
     - Django==1.4.5
     - django-tagging==0.3.1
-    - django-sendfile==0.3.0
+    - django-sendfile==0.3.6
     - django-taggit==0.10
   when: not {{ use_cache }} and not {{ no_network }}
 
@@ -52,7 +53,7 @@
   with_items:
     - Django==1.4.5
     - django-tagging==0.3.1
-    - django-sendfile==0.3.0
+    - django-sendfile==0.3.6
     - django-taggit==0.10
   tags:
     - download


### PR DESCRIPTION
The version 0.3.0 gives a error trying to install, version 0.3.6 works ok.