### PR TITLE
egrep of the mysql task does not fine enablement

### DIFF
--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -28,6 +28,7 @@
     - name: Start the MySQL service
       service: name={{ mysql_service }}
                state=started
+               state=enabled
 
 # 'localhost' needs to be the last item for idempotency, see
 # http://ansible.cc/docs/modules.html#mysql-user


### PR DESCRIPTION
on my NUC, and after a reboot, mysql was not running. But systemctl start mariadb started it successfully