### PR TITLE
generate and announce the uuid for this install

### DIFF
--- a/roles/1-prep/tasks/computed_vars.yml
+++ b/roles/1-prep/tasks/computed_vars.yml
@@ -50,6 +50,8 @@
       value: '{{ ansible_local["local_facts"]["xsce_branch"] }}'
     - option: 'xsce_commit'
       value: '{{ ansible_local["local_facts"]["xsce_commit"] }}'
+    - option: 'xsce_uuid'
+      value: '{{ ansible_local["local_facts"]["xsce_uuid"] }}'
     - option: 'install_date'
       value: '{{ ansible_date_time["iso8601"] }}'
 

--- a/roles/1-prep/templates/local_facts.fact.j2
+++ b/roles/1-prep/templates/local_facts.fact.j2
@@ -1,5 +1,12 @@
 #!/bin/sh
 . /etc/xsce/xsce.env
+
+# enable this install config to be tracked
+if [ ! -f /etc/xsce/uuid ]; then
+  uuidgen > /etc/xsce/uuid
+fi
+UUID=`cat /etc/xsce/uuid`
+
 cd $XSCE_DIR
 
 # while we're here untrack local vars
@@ -27,5 +34,6 @@ cat <<EOF
 {"phplib_dir" : "$PHPLIB_DIR",
 "xsce_branch" : "$BRANCH",
 "xsce_commit" : "$COMMIT",
+"xsce_uuid"   " "$UUID",
 "xo_model"    : "$XO_VERSION"}
 EOF

--- a/roles/1-prep/templates/local_facts.fact.j2
+++ b/roles/1-prep/templates/local_facts.fact.j2
@@ -34,6 +34,6 @@ cat <<EOF
 {"phplib_dir" : "$PHPLIB_DIR",
 "xsce_branch" : "$BRANCH",
 "xsce_commit" : "$COMMIT",
-"xsce_uuid"   " "$UUID",
+"xsce_uuid"   : "$UUID",
 "xo_model"    : "$XO_VERSION"}
 EOF


### PR DESCRIPTION
As I've been looking at further automating the testing of the server, I've been wanting to merge the results from the tests done be an XO client and the tests tests that the server does on itself. Having a UUID to link data from both seems like a good idea.  I'm looking at couchdb on unleashkids.org as one option.