### PR TITLE
Apr13 fixes

### DIFF
--- a/roles/1-prep/tasks/computed_network.yml
+++ b/roles/1-prep/tasks/computed_network.yml
@@ -86,10 +86,10 @@
     xsce_lan_iface: "{{ discovered_lan_iface }}"
   when: 'discovered_lan_iface != "none"'
 
-- name: if only wireless lan and no wired lan - WiFi is the LAN
+- name: WiFi is on the LAN - use bridging
   set_fact:
-    xsce_lan_iface: "{{ discovered_wireless_iface }}"
-  when: discovered_wireless_iface != "none" and num_lan_interfaces == "1"
+    xsce_lan_iface: br0
+  when: xsce_wireless_lan_iface != "none"
 
 # user disabled interface - overriding the default of auto
 - name: Checking xsce_lan_enabled

--- a/roles/1-prep/tasks/computed_network.yml
+++ b/roles/1-prep/tasks/computed_network.yml
@@ -1,7 +1,7 @@
 # DETECT -- gateway and wireless
 - name: Get a list of slaves from previous config
-  shell: "egrep -rn BRIDGE=br0 /etc/sysconfig/network-scripts | gawk -F'[-:]' '{print $3}'" 
-  register: ifcfg_slaves 
+  shell: "egrep -rn BRIDGE=br0 /etc/sysconfig/network-scripts | gawk -F'[-:]' '{print $3}'"
+  register: ifcfg_slaves
   ignore_errors: True
   changed_when: False
 
@@ -48,6 +48,7 @@
   changed_when: false
 
 # Select an adapter that is not WAN and not wireless
+# if there is more than one the last one wins
 - name: Set xsce discovered lan fact
   set_fact:
     discovered_lan_iface: "{{ item|trim }}"
@@ -63,7 +64,7 @@
 
 # facts are apparently all stored as text, so do text comparisons from here on
 - name: create a simple variable from a compound one
-  set_fact: 
+  set_fact:
       num_lan_interfaces: "{{ num_lan_interfaces_result.stdout|int }}"
 
 # If 2 interfaces found in gateway mode, with one wifi, declare other to be wan
@@ -75,7 +76,7 @@
 #  when: xsce_lan_enabled and xsce_wan_enabled and num_lan_interfaces == "2" and discovered_wireless_iface != "none" and xsce_wan_iface == "none"
 
 - name: Set the variable for wireless_iface if present
-  set_fact: 
+  set_fact:
        xsce_wireless_lan_iface: "{{ discovered_wireless_iface }}"
   when: discovered_wireless_iface != "none"
 

--- a/roles/1-prep/tasks/computed_network.yml
+++ b/roles/1-prep/tasks/computed_network.yml
@@ -42,7 +42,7 @@
 
 # LAN - pick non WAN's
 - name: Create list of  LAN (non wan) ifaces
-  shell: "/sbin/ip link show | grep -v  -e lo -e br0: -e tun -e {{ xsce_wan_iface }}| grep mtu | gawk -F: '{print $2}' "
+  shell: "/sbin/ip link show | grep -v  -e lo -e br0: -e tun -e {{ discovered_wan_iface }}| grep mtu | gawk -F: '{print $2}' "
   register: lan_list_result
   ignore_errors: True
   changed_when: false

--- a/roles/1-prep/tasks/computed_network.yml
+++ b/roles/1-prep/tasks/computed_network.yml
@@ -11,7 +11,6 @@
     discovered_wan_iface: "{{ ansible_default_ipv4.alias }}"
   when: 'ansible_default_ipv4.gateway is defined'
 
-
 # WIRELESS -- if any wireless is detected as gateway, it becomes WAN
 - name: Look for any wireless interfaces
   register: wireless_list
@@ -84,7 +83,12 @@
 - name: Setting detected lan
   set_fact:
     xsce_lan_iface: "{{ discovered_lan_iface }}"
-  when: 'discovered_lan_iface != "none"'
+  when: 'discovered_lan_iface != "none" and num_lan_interfaces == "1"'
+
+- name: 2 devices on the LAN - use bridging
+   set_fact:
+     xsce_lan_iface: br0
+  when: 'discovered_lan_iface != "none" and num_lan_interfaces == "2"'
 
 - name: WiFi is on the LAN - use bridging
   set_fact:

--- a/roles/1-prep/tasks/computed_network.yml
+++ b/roles/1-prep/tasks/computed_network.yml
@@ -16,7 +16,7 @@
   register: wireless_list
   shell: "ls -la /sys/class/net/*/phy80211 | awk -F / '{print $5}'"
   ignore_errors: True
- 
+
 # maybe never TODO: deal with more that one wireless device last match wins
 - name: Set the discovered wireless, if found
   set_fact:
@@ -41,7 +41,7 @@
 
 # LAN - pick non WAN's
 - name: Create list of  LAN (non wan) ifaces
-  shell: "/sbin/ip link show | grep -v  -e lo -e br0: -e tun -e {{ discovered_wan_iface }}| grep mtu | gawk -F: '{print $2}' "
+  shell: "/sbin/ip link show | grep -v -e wwlan -e ppp -e lo -e br0: -e tun -e {{ discovered_wan_iface }}| grep mtu | gawk -F: '{print $2}' "
   register: lan_list_result
   ignore_errors: True
   changed_when: false

--- a/roles/1-prep/tasks/computed_network.yml
+++ b/roles/1-prep/tasks/computed_network.yml
@@ -80,16 +80,16 @@
        xsce_wireless_lan_iface: "{{ discovered_wireless_iface }}"
   when: discovered_wireless_iface != "none"
 
-#- name: if only one lan interface, combine wireless and lan
-#  set_fact:
-#    discovered_lan_iface: "{{ discovered_wireless_iface }}"
-#  when: discovered_wireless_iface != "none" and num_lan_interfaces == "1"
-
 # use value only if present
 - name: Setting detected lan
   set_fact:
     xsce_lan_iface: "{{ discovered_lan_iface }}"
   when: 'discovered_lan_iface != "none"'
+
+- name: if only wireless lan and no wired lan - WiFi is the LAN
+  set_fact:
+    xsce_lan_iface: "{{ discovered_wireless_iface }}"
+  when: discovered_wireless_iface != "none" and num_lan_interfaces == "1"
 
 # user disabled interface - overriding the default of auto
 - name: Checking xsce_lan_enabled

--- a/roles/1-prep/tasks/computed_network.yml
+++ b/roles/1-prep/tasks/computed_network.yml
@@ -11,14 +11,14 @@
     discovered_wan_iface: "{{ ansible_default_ipv4.alias }}"
   when: 'ansible_default_ipv4.gateway is defined'
 
-# WIRELESS -- if wireless is detected as gateway, it becomes WAN candidate
-- name: Look for any wireless interfaces -- pick first one if more than one exists
-  shell: "cat /proc/net/wireless | grep -v -e Inter -e face | gawk -F: '{print $1}' | head -n1"
-  register: wireless_list
-  ignore_errors: True
-  changed_when: False
 
-# maybe never TODO: deal with more that one wireless device
+# WIRELESS -- if any wireless is detected as gateway, it becomes WAN
+- name: Look for any wireless interfaces
+  register: wireless_list
+  shell: "ls -la /sys/class/net/*/phy80211 | awk -F / '{print $5}'"
+  ignore_errors: True
+ 
+# maybe never TODO: deal with more that one wireless device last match wins
 - name: Set the discovered wireless, if found
   set_fact:
      discovered_wireless_iface: "{{ wireless_list.stdout|trim }}"

--- a/roles/2-common/tasks/yum.yml
+++ b/roles/2-common/tasks/yum.yml
@@ -33,6 +33,7 @@
   yum: name={{ item }}
        state=latest
   with_items:
+   - NetworkManager
    - bash
    - iptables
    - vim-minimal # ejabberd erlang does not update this properly

--- a/roles/2-common/tasks/yum.yml
+++ b/roles/2-common/tasks/yum.yml
@@ -24,6 +24,8 @@
    - i2c-tools
    - bridge-utils
    - usbutils
+   - hostapd
+   - wpa_supplicant
   tags:
     - download
 

--- a/roles/network/tasks/NM.yml
+++ b/roles/network/tasks/NM.yml
@@ -1,12 +1,3 @@
-# This is a dog's breakfast, but with ansible 1.6.3 service: name=NetworkManager state=restarted doesn't work
-- name: Update NM packages
-  yum: name={{ item }}
-       state=latest
-  with_items:
-   - NetworkManager
-  tags:
-    - download
-
 - name: restart NetworkManager services
   service: name=NetworkManager
            enabled=yes

--- a/roles/network/tasks/hostapd.yml
+++ b/roles/network/tasks/hostapd.yml
@@ -1,13 +1,3 @@
-- name: Install the standard hostapd if possible
-  yum:  name={{ item }}
-        state=present
-  with_items:
-       - hostapd
-       - wpa_supplicant
-  when: not {{ use_cache }} and not {{ no_network }}
-  tags:
-    - download
-
 - name: Download substitute software
   get_url: url="{{ xsce_download_url }}/{{ item }}"  dest={{ downloads_dir}}/{{ item }}
   with_items:

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -118,6 +118,7 @@
 - name: Stop the Access Point Hostapd program
   service: name=hostapd.service
            state=stopped
+  ignore_errors: yes
 
 - name: Now get them out of the way
   shell: "rm -f {{ item }} "

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -126,6 +126,19 @@
   with_items:
     - "{{ ifcfg_files.stdout_lines }}"
 
+# might have wifi info if wireless is used as uplink.
+- name: Rename supplied gateway ifcfg file to WAN if present
+  shell: "mv /etc/sysconfig/network-scripts/ifcfg-{{ discovered_wan_iface }} /etc/sysconfig/network-scripts/ifcfg-WAN"
+  ignore_errors: True
+  when: discovered_wan_iface != "none"
+
+# set user_wan_iface: <device> for static
+# use wan_* for static info
+- name: Supply ifcfg-WAN file
+  template: src=network/ifcfg-WAN.j2
+            dest=/etc/sysconfig/network-scripts/ifcfg-WAN
+  when: 'xsce_wan_iface != "none" and wan_ip != "dhcp"'
+
 #- name: Restart NM if gateway was not detected, and not disabled
 #  include: NM.yml
 #  when: discovered_wan_iface == "none" and user_wan_iface == "auto"
@@ -134,13 +147,6 @@
 #  setup: filter=ansible_local
 #  include: ../../../roles/1-prep/tasks/computed_network.yml
 #  when: discovered_wan_iface == "none" and user_wan_iface == "auto"
-
-# set user_wan_iface: <device> for static
-# use wan_* for static info
-- name: Supply ifcfg-WAN file
-  template: src=network/ifcfg-WAN.j2
-            dest=/etc/sysconfig/network-scripts/ifcfg-WAN
-  when: 'xsce_wan_iface != "none" and wan_ip != "dhcp"'
 
 - name: Configuring LAN interface as xsce_lan_iface
   template: src=network/ifcfg.j2

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -120,8 +120,9 @@
            state=stopped
   ignore_errors: yes
 
-- name: Now get them out of the way
+- name: Now delete all non-gateway ifcfg files
   shell: "rm -f {{ item }} "
+  when: item|trim != discovered_wan_iface
   with_items:
     - "{{ ifcfg_files.stdout_lines }}"
 

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -126,13 +126,13 @@
 
 #- name: Restart NM if gateway was not detected, and not disabled
 #  include: NM.yml
-#  when: discovered_wan_iface == "none" and user_wan_iface == "auto" 
+#  when: discovered_wan_iface == "none" and user_wan_iface == "auto"
 
 #- name: Re-detect network facts if NM was restarted.
 #  setup: filter=ansible_local
-#  include: ../../../roles/1-prep/tasks/computed_network.yml  
-#  when: discovered_wan_iface == "none" and user_wan_iface == "auto" 
- 
+#  include: ../../../roles/1-prep/tasks/computed_network.yml
+#  when: discovered_wan_iface == "none" and user_wan_iface == "auto"
+
 # set user_wan_iface: <device> for static
 # use wan_* for static info
 - name: Supply ifcfg-WAN file
@@ -153,10 +153,11 @@
               dest=/etc/sysconfig/network-scripts/ifcfg-LAN
   when: xsce_lan_iface == "{{ xsce_wireless_lan_iface }}"
 
+# can be more than one wired interface
 - name: Wired enslaving ## lan_list_result ## to Bridge
   template: src=network/ifcfg-slave.j2
             dest=/etc/sysconfig/network-scripts/ifcfg-{{ item|trim }}
-  when: xsce_lan_iface == "br0" and item|trim != xsce_wireless_lan_iface 
+  when: xsce_lan_iface == "br0" and item|trim != xsce_wireless_lan_iface
   with_items:
       - "{{ lan_list_result.stdout_lines }}"
 
@@ -168,11 +169,11 @@
     - network
 
 - include: restart.yml
-  when: not installing  
+  when: not installing
   tags:
     - network
 
 - include: hostapd.yml
-  when: not installing  
+  when: not installing
   tags:
     - network


### PR DESCRIPTION
The first 2 commits help document the logic, and high light what I believe to be the cause of the behavior that George has observed. In idem 24, 28 is the correct result as setting br0 or use_bridging would have this result. This can be observed in the xsce.ini file's entries:
user_lan = br0
computed_lan = br0

What I believe George is bumping into in idem 25, 27, 29 is a failure to detect the wireless device properly. The WiFi device should be excluded from the lan_list but is not, not an issue when bridging both end up in the bridge, as such one would see:
TASK: [1-prep | Look for any wireless interfaces -- pick first one if more than one exists] *** 
ok: [127.0.0.1]

TASK: [1-prep | Set the discovered wireless, if found] ************************ 
skipping: [127.0.0.1]                                <<<<<<<< note the skip

TASK: [1-prep | Setting wan if detected] ************************************** 
ok: [127.0.0.1]

TASK: [1-prep | Checking xsce_wan_enabled] ************************************ 
skipping: [127.0.0.1]

TASK: [1-prep | setting user WAN fact] **************************************** 
skipping: [127.0.0.1]

TASK: [1-prep | Create list of  LAN (non wan) ifaces] ************************* 
ok: [127.0.0.1]

TASK: [1-prep | Set xsce discovered lan fact] ********************************* 
ok: [127.0.0.1] => (item= eth0)
ok: [127.0.0.1] => (item= wlan0)         <<<<<<<<< This should be excluded here

TASK: [1-prep | Count LAN ifaces] ********************************************* 
ok: [127.0.0.1]

TASK: [1-prep | create a simple variable from a compound one] ***************** 
ok: [127.0.0.1]

TASK: [1-prep | Set the variable for wireless_iface if present] *************** 
skipping: [127.0.0.1]                                             <<<<<<<<<< note the skip

TASK: [1-prep | Setting detected lan] ***************************************** 
ok: [127.0.0.1]

TASK: [1-prep | Checking xsce_lan_enabled] ************************************ 
skipping: [127.0.0.1]

TASK: [1-prep | Setting user LAN for bridging] ******************************** 
ok: [127.0.0.1]

TASK: [1-prep | Setting user LAN fact] **************************************** 
ok: [127.0.0.1]

With the xsce.ini file looking like:
lan_enabled = True
num_lan_interfaces = 2
discovered_wireless_iface = none
xsce_wireless_lan_iface = none
detected_lan = wlan0                       <<<<<< note it's the last match
user_lan = br0
computed_lan = br0

Non-bridging is the same except for:
user_lan = auto
computed_lan = wlan0                     <<<<<<<  should of been the wired interface



When I populate vars/l* with discovered_wireless_iface: wlan0  to override the detection the results are:

TASK: [1-prep | Look for any wireless interfaces -- pick first one if more than one exists] *** 
ok: [127.0.0.1]

TASK: [1-prep | Set the discovered wireless, if found] ************************ 
skipping: [127.0.0.1]                                     <<<<<< note the skip

TASK: [1-prep | Setting wan if detected] ************************************** 
ok: [127.0.0.1]

TASK: [1-prep | Checking xsce_wan_enabled] ************************************ 
skipping: [127.0.0.1]

TASK: [1-prep | setting user WAN fact] **************************************** 
skipping: [127.0.0.1]

TASK: [1-prep | Create list of  LAN (non wan) ifaces] ************************* 
ok: [127.0.0.1]

TASK: [1-prep | Set xsce discovered lan fact] ********************************* 
ok: [127.0.0.1] => (item= eth0)
skipping: [127.0.0.1] => (item= wlan0)                     <<<<<< this is what should happen

TASK: [1-prep | Count LAN ifaces] ********************************************* 
ok: [127.0.0.1]

TASK: [1-prep | create a simple variable from a compound one] ***************** 
ok: [127.0.0.1]

TASK: [1-prep | Set the variable for wireless_iface if present] *************** 
ok: [127.0.0.1]                                                      <<<<<< this is what should happen

TASK: [1-prep | Setting detected lan] ***************************************** 
ok: [127.0.0.1]

TASK: [1-prep | Checking xsce_lan_enabled] ************************************ 
skipping: [127.0.0.1]

TASK: [1-prep | Setting user LAN for bridging] ******************************** 
ok: [127.0.0.1]

TASK: [1-prep | Setting user LAN fact] **************************************** 
ok: [127.0.0.1]

The results in the xsce.ini are:
lan_enabled = True
num_lan_interfaces = 2
discovered_wireless_iface = wlan0
xsce_wireless_lan_iface = wlan0
detected_lan = eth0
user_lan = br0
computed_lan = br0

Until the wireless detection is resolved, declare discovered_wireless_iface in vars if you have WiFi present, with or without the use of bridging until a solution if worked up.

af592fa is to allow WiFi if the only lan device, to be ifcfg-LAN without bridging. This will be needed once the WiFi detection is squared away. Think it might be easier just to always use bridging.... Any thoughts?


  