### PR TITLE
NM and network interfere setting up bridge

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -153,13 +153,13 @@
             dest=/etc/sysconfig/network-scripts/ifcfg-LAN
   when: xsce_lan_iface != "none"
 
-#- name: Turn off NM for WiFi LAN
-#  lineinfile: state=present
-#              backrefs=yes
-#              regexp="NM_CONTROLLED"
-#              line="NM_CONTROLLED=no"
-#              dest=/etc/sysconfig/network-scripts/ifcfg-LAN
-#  when: xsce_lan_iface == "{{ xsce_wireless_lan_iface }}"
+- name: Turn off NM for WiFi LAN
+  lineinfile: state=present
+              backrefs=yes
+              regexp="NM_CONTROLLED"
+              line="NM_CONTROLLED=no"
+              dest=/etc/sysconfig/network-scripts/ifcfg-LAN
+  when: xsce_lan_iface == "{{ xsce_wireless_lan_iface }}"
 
 # can be more than one wired interface
 - name: Wired enslaving ## lan_list_result ## to Bridge


### PR DESCRIPTION
Discovered that with 2 lan devices, (one wifi), network service refused to start, saying that it could not join <device> to br0 because it was already part of a bridge. This PR let ./runansible run to completion