### PR TITLE
after install-console, cannot acces from remote browser, firewalld is ru...

### DIFF
--- a/roles/network/tasks/iptables.yml
+++ b/roles/network/tasks/iptables.yml
@@ -1,6 +1,7 @@
 - name: Disable firewalld service
   service: name=firewalld
            enabled=no
+           state=stopped
 
 - name: Install iptables service package
   yum: name=iptables-services


### PR DESCRIPTION
Starting from fresh netinst x86_64, NUC, running asnible ./install_console, cannot access console from remove browser because firewalld is still running. Network discovery had decided appliance (I forgot to plug in the USB dongle).