### PR TITLE
give kalite-serve longer to start up

### DIFF
--- a/roles/kalite/tasks/enable.yml
+++ b/roles/kalite/tasks/enable.yml
@@ -8,6 +8,8 @@
   service: name=kalite-serve 
            enabled=yes
            state=started           
+  async: 60
+  poll: 5
   when: kalite_enabled  
 
 - name: Disable kalite cron server


### PR DESCRIPTION
Had a failure on the 2830 NUC while kalite-serve was starting up. Logs not helpful. Started ok from the command line, but took about 30 seconds.