### PR TITLE
Always block rpc/DBs that are bound to 0.0.0.0

### DIFF
--- a/roles/network/templates/gateway/xs-gen-iptables
+++ b/roles/network/templates/gateway/xs-gen-iptables
@@ -7,6 +7,23 @@ clear_fw() {
 $IPTABLES -F
 $IPTABLES -t nat -F
 $IPTABLES -X
+
+# first match wins
+# Always accept loopback traffic 
+$IPTABLES -A INPUT -i lo -j ACCEPT
+
+# Always drop rpc 
+$IPTABLES -A INPUT -p tcp --dport 111 -j DROP
+$IPTABLES -A INPUT -p udp --dport 111 -j DROP
+# mysql
+$IPTABLES -A INPUT -p tcp --dport 3306 -j DROP
+$IPTABLES -A INPUT -p udp --dport 3306 -j DROP
+# postgre - not needed listens on lo only
+$IPTABLES -A INPUT -p tcp --dport 5432 -j DROP
+$IPTABLES -A INPUT -p udp --dport 5432 -j DROP
+# couchdb
+$IPTABLES -A INPUT -p tcp --dport 5984 -j DROP
+$IPTABLES -A INPUT -p udp --dport 5984 -j DROP
 }
 
 if [  "x$WANIF" == "x" ]; then


### PR DESCRIPTION
systemd unit files seem to just start the DB daemons, with no provisions on changing the bound interfaces in some of the config files(if at all used) for the daemons. The exceptions being posgresql that has a config file allowing the address to bind to be set, but is included here just for completeness. The other is rpcbind that takes arguments via /etc/sysconfig/rpcbind. Think this is faster than spending the time to alter config files and retesting them. These firewall rule will be loaded in all cases, addressing an avenue for a potential malicious act. Port scanning from either WAN or LAN should show these ports as closed or filtered depending on the tool you used to test with.