### PR TITLE
add other ini entries into openvpn PR

### DIFF
--- a/roles/ajenti/tasks/main.yml
+++ b/roles/ajenti/tasks/main.yml
@@ -64,3 +64,16 @@
            enabled=yes
            state=restarted
   when: ajenti_enabled
+
+- name: Add ajenti to service list
+  ini_file: dest='{{ service_filelist }}'
+            section=ajenti
+            option='{{ item.option }}'
+            value='{{ item.value }}'
+  with_items:
+    - option: name
+      value: ajenti
+    - option: description
+      value: "Ajenti is a client server systems administration tool controlled by a web browser"
+    - option: enabled
+      value: "{{ ajenti_enabled }}"

--- a/roles/idmgr/tasks/main.yml
+++ b/roles/idmgr/tasks/main.yml
@@ -68,3 +68,16 @@
              regexp='^#allowsftp'
              insertafter='^#allowsftp'
              line=allowsftp
+
+- name: Add idmgr to service list
+  ini_file: dest='{{ service_filelist }}'
+            section=idmgr
+            option='{{ item.option }}'
+            value='{{ item.value }}'
+  with_items:
+    - option: name
+      value: idmgr
+    - option: description
+      value: "Idmgr is an automatic identity manager for XO clients which enables automatic backup"
+    - option: enabled
+      value: "{{ xo_services_enabled }}"

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -32,3 +32,15 @@
 #- name: Restart monit service
 #  command: service monit restart
 
+- name: Add monit to service list
+  ini_file: dest='{{ service_filelist }}'
+            section=monit
+            option='{{ item.option }}'
+            value='{{ item.value }}'
+  with_items:
+    - option: name
+      value: monit
+    - option: description
+      value: "Monit is a background service monitor which can correct problems, send email, restart services"
+    - option: enabled
+      value: "{{ monit_enabled }}"

--- a/roles/network/tasks/enable.yml
+++ b/roles/network/tasks/enable.yml
@@ -62,3 +62,42 @@
   service: name=wondershaper
            enabled=no
   when: not wondershaper_enabled
+
+- name: Add squid to service list
+  ini_file: dest='{{ service_filelist }}'
+            section=squid
+            option='{{ item.option }}'
+            value='{{ item.value }}'
+  with_items:
+    - option: name
+      value: squid
+    - option: description
+      value: "Squid caches web pages the first time they are accessed, and pulls them from the cache thereafter"
+    - option: enabled
+      value: "{{ squid_enabled }}"
+
+- name: Add dansguardian to service list
+  ini_file: dest='{{ service_filelist }}'
+            section=dansguardian
+            option='{{ item.option }}'
+            value='{{ item.value }}'
+  with_items:
+    - option: name
+      value: dansguardian
+    - option: description
+      value: "Dansguardian searches web content for sexual references and denies access when found"
+    - option: enabled
+      value: "{{ dansguardian_enabled }}"
+
+- name: Add wondershaper to service list
+  ini_file: dest='{{ service_filelist }}'
+            section=wondershaper
+            option='{{ item.option }}'
+            value='{{ item.value }}'
+  with_items:
+    - option: name
+      value: wondershaper
+    - option: description
+      value: "Wondershaper is a command line tool to set maximum transfer rates for network adapters"
+    - option: enabled
+      value: "{{ wondershaper_enabled }}"

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -48,3 +48,16 @@
     - samba
   when : not samba_enabled
 
+- name: Add samba to service list
+  ini_file: dest='{{ service_filelist }}'
+            section=samba
+            option='{{ item.option }}'
+            value='{{ item.value }}'
+  with_items:
+    - option: name
+      value: samba
+    - option: description
+      value: "Samba is a Microsoft compatible remote file access system  - generalized to CIFS --common internet file system"
+    - option: enabled
+      value: "{{ samba_enabled }}"
+


### PR DESCRIPTION
My earlier attempt to disable firewalld was not successful. After clean install of i686 on i3 NUC, and running ./install-console, firewall was enabled, and iptables was disabled --- not ready for a reboot.

I added in the flag for iptables_enabled so that we could discuss it. I think it's needed, but I'm wrong lots of the time