### PR TITLE
I did'nt push this last time, do it now

### DIFF
--- a/roles/2-common/tasks/yum.yml
+++ b/roles/2-common/tasks/yum.yml
@@ -38,6 +38,7 @@
    - bash
    - iptables
    - vim-minimal # ejabberd erlang does not update this properly
+   - dbus-glib   # NM does not update this properly
   tags:
     - download
 


### PR DESCRIPTION
x86_64 -- NM fails to start with a missing symbol dbus-glib fixes it