### PR TITLE
maybe openssl will fix the stall during pear install on xos

### DIFF
--- a/roles/2-common/tasks/yum.yml
+++ b/roles/2-common/tasks/yum.yml
@@ -27,6 +27,7 @@
    - hostapd
    - wpa_supplicant
    - wget
+   - openssl   #FC 18 does not supply, but pear requires
   tags:
     - download
 


### PR DESCRIPTION
The stall on setting the pear directory on XO4 and XO1.5 was corrected. Earlier I had just done a "yum update" and caused this error to disappear. It's not clear to me whether it is better to update all of fc18 on XO's, or just the minimal set. We can start with the latter.  I don't know why James Cameron did not update everything with his new spin.