### PR TITLE
add in a 5 minute delay while kalite installs the database

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -43,6 +43,8 @@
             
 - name: Run the install
   command: "/tmp/kalite_install.exp"
+  async: 300
+  poll: 10
 
 - name: Create kalite service(s) and support scripts
   template: backup=yes


### PR DESCRIPTION
Tested on i3NUC, I put in a 300 second delay, it reported state every 10 seconds, and used 80 seconds before completion.

Tim mentioned in an email that he thought Jerry had put in a delay. But I don't find it.