### PR TITLE
add response to expect file for assessment package

### DIFF
--- a/roles/kalite/tasks/main.yml
+++ b/roles/kalite/tasks/main.yml
@@ -11,6 +11,7 @@
   git: repo={{ kalite_repo_url }}
        dest={{ downloads_dir }}/ka-lite
        depth=1
+       version="0.13.x"
   when: not {{ use_cache }}
   tags:
     - download2

--- a/roles/kalite/templates/kalite_install.exp.j2
+++ b/roles/kalite/templates/kalite_install.exp.j2
@@ -9,4 +9,5 @@ expect "Password:" {send "{{ kalite_password }}\r"}
 expect "Password (again):" {send "{{ kalite_password }}\r"}
 expect "Please enter a name for this server" {send "{{ kalite_server_name }}\r"}
 expect "Please enter a one-line description" {send "\r"}
+expect "Do you wish to download the assessment items package now?" {send "yes\r"}
 expect "CONGRATULATIONS!" {exit}


### PR DESCRIPTION
I think we want to stay current with ka-lite. But the other approach would be to specify branch 0.12