### PR TITLE
freeze ka-lite version to our expect file

### DIFF
--- a/roles/kalite/tasks/main.yml
+++ b/roles/kalite/tasks/main.yml
@@ -11,6 +11,7 @@
   git: repo={{ kalite_repo_url }}
        dest={{ downloads_dir }}/ka-lite
        depth=1
+       version="0.12.x"
   when: not {{ use_cache }}
   tags:
     - download2


### PR DESCRIPTION
I want to test this on a new install before it is merged into stable