### PR TITLE
Add Opensearchserver to XSCE

### DIFF
--- a/roles/6-generic-apps/meta/main.yml
+++ b/roles/6-generic-apps/meta/main.yml
@@ -2,3 +2,4 @@ dependencies:
    - { role: mysql, tags: ['generic','mysql'], when: mysql_install }
    - { role: elgg, tags: ['generic','elgg'], when: elgg_install }
    - { role: owncloud, tags: ['generic','owncloud'], when: owncloud_install }
+   - { role: opensearchserver, tags: ['generic','opensearchserver'], when: oss_install }

--- a/roles/opensearchserver/README.rst
+++ b/roles/opensearchserver/README.rst
@@ -1,0 +1,16 @@
+===============
+OpenSearchServer README
+===============
+
+Open-source enterprise class search engine software.
+
+http://www.opensearchserver.com
+
+After Installation
+------------------
+
+Locations
+---------
+
+Parameters
+----------

--- a/roles/opensearchserver/defaults/main.yml
+++ b/roles/opensearchserver/defaults/main.yml
@@ -1,0 +1,3 @@
+oss_url: /oss
+oss_install: True
+oss_enabled: True

--- a/roles/opensearchserver/tasks/main.yml
+++ b/roles/opensearchserver/tasks/main.yml
@@ -1,0 +1,18 @@
+- name: Get the OpenSearchServer software
+  command: wget -c -t 20 http://people.sugarlabs.org/anish/opensearchserver-1.5.12-b940.rpm -O {{ downloads_dir}}/opensearchserver.rpm
+  when: not {{ use_cache }} and not {{ no_network }}
+  tags:
+    - download2
+
+- name: Install the package
+  yum: name={{ downloads_dir}}/opensearchserver.rpm
+       state=present
+
+- name: Configure the server to run on port 9092 (as cockpit runs on port 9090 in fedora)
+  replace: dest='/etc/opensearchserver' regexp='SERVER_PORT=9090' replace='SERVER_PORT=9092'
+
+- name: Enable service
+  service: name=opensearchserver enabled=yes
+
+- name: (Re)start service
+  command: service opensearchserver restart


### PR DESCRIPTION
* Retrieves the rpm package and stores it in downloads
* Installs the rpm. Enables the service
* Configures the server to run at port 9092 instead of 9090 (on which cockpit runs in fedora)
* Tested on CentOS 7 x64 VM
* Enabled by default
* Enable/Disable variables created but not really used - also not added to default_vars.yml