### PR TITLE
Add dokuwiki to XSCE 

### DIFF
--- a/roles/6-generic-apps/meta/main.yml
+++ b/roles/6-generic-apps/meta/main.yml
@@ -2,3 +2,4 @@ dependencies:
    - { role: mysql, tags: ['generic','mysql'], when: mysql_install }
    - { role: elgg, tags: ['generic','elgg'], when: elgg_install }
    - { role: owncloud, tags: ['generic','owncloud'], when: owncloud_install }
+   - { role: dokuwiki, tags: ['generic','dokuwiki'], when: dokuwiki_install }

--- a/roles/dokuwiki/README.rst
+++ b/roles/dokuwiki/README.rst
@@ -1,0 +1,36 @@
+===============
+Dokuwiki README
+===============
+
+DokuWiki is a simple to use and highly versatile Open Source wiki software that 
+doesn't require a database. It is loved by users for its clean and readable
+syntax. The ease of maintenance, backup and integration makes it an 
+administrator's favorite. Built in access controls and authentication connectors
+make DokuWiki especially useful in the enterprise context and the large number of
+plugins contributed by its vibrant community allow for a broad range of use cases
+beyond a traditional wiki. 
+
+http://dokuwiki.org/
+
+After Installation
+------------------
+
+Head to http://schoolserver.lan/wiki. The webpage will probably throw up an error
+saying you haven't run install.php yet, with a link to it. Click the link to be 
+taken to the install page which does the initial configuration of the wiki. After
+this, you should be all set!
+
+Locations
+---------
+
+Everything is copied to the /opt/dokuwiki folder. An apache configuration file is
+installed in the usual conf.d directory.
+
+Parameters
+----------
+None yet other than the basic enabled/disabled. Haven't really tested if they work.
+
+Todo
+----
+* Preinstall some popular plugins.
+* Additional XSCE customizations.

--- a/roles/dokuwiki/defaults/main.yml
+++ b/roles/dokuwiki/defaults/main.yml
@@ -1,0 +1,3 @@
+dokuwiki_url: /wiki
+dokuwiki_install: True
+dokuwiki_enabled: True

--- a/roles/dokuwiki/tasks/install.yml
+++ b/roles/dokuwiki/tasks/install.yml
@@ -1,0 +1,26 @@
+- name: Get the Dokuwiki software
+  get_url: url="http://download.dokuwiki.org/src/dokuwiki/dokuwiki-stable.tgz"  dest={{ downloads_dir}}/dokuwiki-stable.tgz
+  when: not {{ use_cache }} and not {{ no_network }}
+  tags:
+    - download2
+
+- name: Copy it to permanent location /opt
+  unarchive: src={{ downloads_dir}}/dokuwiki-stable.tgz  dest=/library
+
+- name: Rename /library/dokuwiki* to /library/dokuwiki
+  shell: if [ ! -d /library/dokuwiki ]; then mv /library/dokuwiki* /library/dokuwiki; fi
+
+- name: Install config file for dokuwiki in Apache
+  template: src=dokuwiki.conf.j2 dest=/etc/httpd/conf.d/dokuwiki.conf
+  when: dokuwiki_enabled
+
+- name: Change permissions on engine directory so apache can write
+  file: path=/library/dokuwiki owner=apache mode=0755 state=directory recurse=yes
+
+- name: Restart apache, so it picks up the new aliases
+  service: name=httpd state=restarted
+
+- name: Remove httpd conf file if we are disabled
+  file: path=/etc/httpd/conf.d/dokuwiki.conf
+        state=absent 
+  when: not dokuwiki_enabled

--- a/roles/dokuwiki/tasks/install.yml
+++ b/roles/dokuwiki/tasks/install.yml
@@ -4,7 +4,7 @@
   tags:
     - download2
 
-- name: Copy it to permanent location /opt
+- name: Copy it to permanent location /library
   unarchive: src={{ downloads_dir}}/dokuwiki-stable.tgz  dest=/library
 
 - name: Rename /library/dokuwiki* to /library/dokuwiki

--- a/roles/dokuwiki/tasks/main.yml
+++ b/roles/dokuwiki/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Get the Dokuwiki software
+  get_url: url="http://download.dokuwiki.org/src/dokuwiki/dokuwiki-stable.tgz"  dest={{ downloads_dir}}/dokuwiki-stable.tgz
+  when: not {{ use_cache }} and not {{ no_network }}
+  tags:
+    - download2
+
+- name: Copy it to permanent location /opt
+  unarchive: src={{ downloads_dir}}/dokuwiki-stable.tgz  dest=/opt
+
+- name: Rename /opt/dokuwiki* to /opt/dokuwiki
+  shell: if [ ! -d /opt/dokuwiki ]; then mv /opt/dokuwiki* /opt/dokuwiki; fi
+
+- name: Install config file for dokuwiki in Apache
+  template: src=dokuwiki.conf.j2 dest=/etc/httpd/conf.d/dokuwiki.conf
+
+- name: Change permissions on engine directory so apache can write
+  file: path=/opt/dokuwiki owner=apache mode=0755 state=directory recurse=yes
+
+- name: Restart apache, so it picks up the new aliases
+  service: name=httpd state=restarted

--- a/roles/dokuwiki/tasks/main.yml
+++ b/roles/dokuwiki/tasks/main.yml
@@ -1,20 +1,3 @@
-- name: Get the Dokuwiki software
-  get_url: url="http://download.dokuwiki.org/src/dokuwiki/dokuwiki-stable.tgz"  dest={{ downloads_dir}}/dokuwiki-stable.tgz
-  when: not {{ use_cache }} and not {{ no_network }}
-  tags:
-    - download2
-
-- name: Copy it to permanent location /opt
-  unarchive: src={{ downloads_dir}}/dokuwiki-stable.tgz  dest=/opt
-
-- name: Rename /opt/dokuwiki* to /opt/dokuwiki
-  shell: if [ ! -d /opt/dokuwiki ]; then mv /opt/dokuwiki* /opt/dokuwiki; fi
-
-- name: Install config file for dokuwiki in Apache
-  template: src=dokuwiki.conf.j2 dest=/etc/httpd/conf.d/dokuwiki.conf
-
-- name: Change permissions on engine directory so apache can write
-  file: path=/opt/dokuwiki owner=apache mode=0755 state=directory recurse=yes
-
-- name: Restart apache, so it picks up the new aliases
-  service: name=httpd state=restarted
+- name: Include the install playbook
+  include: install.yml
+  when: dokuwiki_install

--- a/roles/dokuwiki/templates/dokuwiki.conf.j2
+++ b/roles/dokuwiki/templates/dokuwiki.conf.j2
@@ -1,0 +1,8 @@
+RewriteEngine on
+
+Alias /wiki /opt/dokuwiki
+<Directory /opt/dokuwiki>
+    Options Indexes FollowSymLinks
+    AllowOverride All
+    Require all granted
+</Directory>

--- a/roles/dokuwiki/templates/dokuwiki.conf.j2
+++ b/roles/dokuwiki/templates/dokuwiki.conf.j2
@@ -1,7 +1,7 @@
 RewriteEngine on
 
-Alias /wiki /opt/dokuwiki
-<Directory /opt/dokuwiki>
+Alias {{ dokuwiki_url }} /library/dokuwiki
+<Directory /library/dokuwiki>
     Options Indexes FollowSymLinks
     AllowOverride All
     Require all granted


### PR DESCRIPTION
### Notes
* Is enabled to install by default. Gets the latest tarball from the official dokuwiki download location.
* There is no corresponding install/enabled variable entry in default_vars.yml but the variables dokuwiki_installed and dokuwiki_enabled exist AND are used by the playbook.
* Tested on centos x64 VM

#### Changes over previous PR 
* dokuwiki_url is now used as a variable
* dokuwiki now installs in /library instead of /opt
* This _should_ be mergeable :-) 