### PR TITLE
expose the moodle pw in ini file

### DIFF
--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -58,10 +58,6 @@
 - name: Execute moodle startup script
   command: /usr/libexec/moodle-xs-init start
 
-- name: enable use of admin password from login -- initially set to changeme
-  shell: /usr/bin/php /var/www/moodle/web/local/scripts/adminuser-enable.php
-  ignore_errors: true
-
 - name: Restart postgresql-xs
   service: name=postgresql-xs
            state=restarted
@@ -74,6 +70,10 @@
   service: name=moodle-xs
            enabled=yes
            state=started
+
+- name: fetch the administrative password for moodle
+  shell: cat /etc/moodle/adminpw
+  register: moodlepw
 
 - name: add moodle to service list
   ini_file: dest='{{ service_filelist }}'
@@ -89,3 +89,5 @@
       value: /moodle
     - option: enabled
       value: "{{ moodle_enabled }}"
+    - option: adminpw
+      value: "{{ moodlepw.stdout }}"

--- a/roles/moodle/templates/moodle-xs-init
+++ b/roles/moodle/templates/moodle-xs-init
@@ -56,9 +56,9 @@ start() {
 		    --adminfirstname=Admin --adminlastname=OLPC \
 		    --adminusername=admin --adminpassword=changeme \
 		    --adminemail=admin@localhost \
-		    --verbose=0 --interactivelevel=0" apache 2>&1 && \
-                    runuser -s /bin/bash -c "/usr/bin/php /var/www/moodle/web/local/scripts/adminuser-disable.php" apache 2>&1 ) \
-		    >> /var/log/moodle-instupg.log 
+		    --verbose=0 --interactivelevel=0" apache 2>&1 ) #&& \
+        #  runuser -s /bin/bash -c "/usr/bin/php /var/www/moodle/web/local/scripts/adminuser-disable.php" apache 2>&1 ) \
+        # >> /var/log/moodle-instupg.log 
 		if [ $? = 0 ]; then
 		    # success
 		    echo "["`date`"]" Finished install / upgrade - Success >> /var/log/moodle-instupg.log 


### PR DESCRIPTION
I've been wanting to find some way to help non-xo clients administer moodle.  It turns out that during installation, moodle creates a random password, and stores the md5 of that password in the database. The easiest is to bring that initial password into Tim's administrative console, which is itself password protected. In this revision of moodle, there is no cli "reset password" function, as there is in later versions.