### PR TITLE
Team viewer F21+ fixes

### DIFF
--- a/roles/teamviewer/tasks/install.yml
+++ b/roles/teamviewer/tasks/install.yml
@@ -3,13 +3,19 @@
 
 - name: Install xfce group of packages
   shell: "yum groupinstall -y xfce"
-  when: xo_model == "none" and not {{ use_cache }} and not {{ no_network }}
+  when: xo_model == "none" and not {{ use_cache }} and not {{ no_network }} and ansible_distribution_version <= "20"
   tags:
     - download
 
 - name: Install X11 group of packages
   shell: "yum groupinstall -y 'X Window system'"
-  when: xo_model == "none" and not {{ use_cache }} and not {{ no_network }}
+  when: xo_model == "none" and not {{ use_cache }} and not {{ no_network }} and ansible_distribution_version <= "20"
+  tags:
+    - download
+
+- name: Install xfce group of packages
+  shell: yum groupinstall -y "Xfce Desktop" --exclude fedora-release\*
+  when: xo_model == "none" and not {{ use_cache }} and not {{ no_network }} and ansible_distribution_version >= "21"
   tags:
     - download
 

--- a/roles/teamviewer/tasks/install.yml
+++ b/roles/teamviewer/tasks/install.yml
@@ -27,5 +27,6 @@
 
 - name: Do the install of teamviewer, pulling in any required dependencies
   shell: "yum localinstall -y {{ downloads_dir }}/{{ teamviewer_rpm_file }}"
-  when: teamviewer_enable and not {{ use_cache }} and not {{ no_network }}
-
+  when: teamviewer_install and not {{ use_cache }} and not {{ no_network }}
+  tags:
+    - download

--- a/roles/teamviewer/tasks/main.yml
+++ b/roles/teamviewer/tasks/main.yml
@@ -1,3 +1,3 @@
 - name: Install Teamviewer if intel
   include: install.yml
-  when: ansible_architecture == "i386" or ansible_architecture == "x86_64"
+  when: ansible_architecture == "i386" or ansible_architecture == "x86_64" and teamviewer_enable


### PR DESCRIPTION
If run drags in X, on X86_64 then i386 libs are installed also, for these reasons I feel both install and enabled should be set by the user to be able to use this feature. When creating images the download tag will be picked up and the rpms installed as long as install is set, you may have to set enabled also at creation time.