### PR TITLE
Use ansible_pkg_mgr in place of yum

### DIFF
--- a/roles/0-once/tasks/centos.yml
+++ b/roles/0-once/tasks/centos.yml
@@ -2,7 +2,7 @@
   command: echo Starting centos.yml
 
 - name: Install epel-release for CentOS
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=present
   with_items:
    - epel-release

--- a/roles/0-once/tasks/xo.yml
+++ b/roles/0-once/tasks/xo.yml
@@ -26,7 +26,7 @@
               state=present
 
 - name: pre(re)-Install packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=latest
   with_items:
    - usbmount

--- a/roles/2-common/tasks/chrony.yml
+++ b/roles/2-common/tasks/chrony.yml
@@ -1,5 +1,5 @@
 - name: Install chrony package
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=present
   with_items:
    - chrony

--- a/roles/2-common/tasks/fedora.yml
+++ b/roles/2-common/tasks/fedora.yml
@@ -1,5 +1,5 @@
 - name: Install Fedora specifc packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=present
   with_items:
    - mtd-utils

--- a/roles/2-common/tasks/yum.yml
+++ b/roles/2-common/tasks/yum.yml
@@ -3,7 +3,7 @@
   when: ansible_distribution == "Fedora" and ansible_distribution_version|int >= 22
 
 - name: Install common packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=present
   with_items:
    - createrepo
@@ -36,7 +36,7 @@
     - download
 
 - name: Update common packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=latest
   with_items:
    - NetworkManager

--- a/roles/ajenti/tasks/main.yml
+++ b/roles/ajenti/tasks/main.yml
@@ -1,11 +1,11 @@
 - name: Install python-pip package
-  yum: name=python-pip
+  {{ ansible_pkg_mgr }} name=python-pip
        state=installed
   tags:
     - download
 
 - name: Install required libraries
-  yum: name={{ item.pkg }}
+  {{ ansible_pkg_mgr }} name={{ item.pkg }}
        state=installed
   with_items:
     - pkg: python-imaging

--- a/roles/authserver/tasks/main.yml
+++ b/roles/authserver/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: check pip is installed
-  yum: name=python-pip
+  {{ ansible_pkg_mgr }} name=python-pip
        state=present
   tags:
     - download
@@ -16,7 +16,7 @@
        extra_args="--no-index --find-links=file://{{ pip_packages_dir }}"
 
 - name: install gunicorn
-  yum: name=python-gunicorn
+  {{ ansible_pkg_mgr }} name=python-gunicorn
        state=present
   tags:
     - download

--- a/roles/awstats/tasks/install.yml
+++ b/roles/awstats/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: Install awstats package
-  yum: pkg={{ item }} state=installed
+  {{ ansible_pkg_mgr }} pkg={{ item }} state=installed
   with_items:
     - awstats
     - mod_ssl

--- a/roles/ejabberd/tasks/main.yml
+++ b/roles/ejabberd/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install ejabberd packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
    - ejabberd-2.1.11

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install httpd required packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
     - httpd

--- a/roles/idmgr/tasks/main.yml
+++ b/roles/idmgr/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install idmgr packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
    - ds-backup-server

--- a/roles/iiab/tasks/main.yml
+++ b/roles/iiab/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install IIAB required packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=present
   with_items:
     - python-pip

--- a/roles/kalite/tasks/main.yml
+++ b/roles/kalite/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install dependent packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
     - python-psutil

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install monit package
-  yum: name=monit
+  {{ ansible_pkg_mgr }} name=monit
        state=present
   tags:
     - download

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install moodle required packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=present
   with_items:
     - moodle-xs

--- a/roles/munin/tasks/main.yml
+++ b/roles/munin/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install munin package
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=present
   with_items:
     - munin

--- a/roles/mysql/tasks/centos.yml
+++ b/roles/mysql/tasks/centos.yml
@@ -1,5 +1,5 @@
     - name: Install MySQL
-      yum: name={{ item }}
+      {{ ansible_pkg_mgr }} name={{ item }}
       with_items:
         - mysql-connector-python
         - mariadb-server

--- a/roles/mysql/tasks/fedora.yml
+++ b/roles/mysql/tasks/fedora.yml
@@ -1,4 +1,4 @@
     - name: Install MySQL
-      yum: name={{ item }}
+      {{ ansible_pkg_mgr }} name={{ item }}
       with_items:
         - mysql-server

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -1,5 +1,5 @@
     - name: Install MySQL
-      yum: name={{ item }}
+      {{ ansible_pkg_mgr }} name={{ item }}
       with_items:
         - MySQL-python
         - mysql

--- a/roles/network/tasks/avahi.yml
+++ b/roles/network/tasks/avahi.yml
@@ -1,5 +1,5 @@
 - name: Install avahi package
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=present
   with_items:
    - nss-mdns

--- a/roles/network/tasks/dhcpd.yml
+++ b/roles/network/tasks/dhcpd.yml
@@ -1,5 +1,5 @@
 - name: Install dhcp package
-  yum: name=dhcp
+  {{ ansible_pkg_mgr }} name=dhcp
        state=installed
   tags:
     - download

--- a/roles/network/tasks/iptables.yml
+++ b/roles/network/tasks/iptables.yml
@@ -12,7 +12,7 @@
         state=absent
 
 - name: Install iptables service package
-  yum: name=iptables-services
+  {{ ansible_pkg_mgr }} name=iptables-services
        state=installed
   tags:
     - download

--- a/roles/network/tasks/named.yml
+++ b/roles/network/tasks/named.yml
@@ -1,5 +1,5 @@
 - name: Install named packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
    - bind

--- a/roles/network/tasks/squid.yml
+++ b/roles/network/tasks/squid.yml
@@ -1,5 +1,5 @@
 - name: Install squid packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
     - squid

--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install openvpn packages
-  yum:  name={{ item }}
+  {{ ansible_pkg_mgr }}  name={{ item }}
         state=present
   with_items:
         - openvpn

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -1,7 +1,7 @@
 # we need to install the rpm in order to get the dependencies
 
 - name: Install owncloud package
-  yum: pkg={{ item }} state=installed
+  {{ ansible_pkg_mgr }} pkg={{ item }} state=installed
   with_items:
   - owncloud
   tags:

--- a/roles/pathagar/tasks/main.yml
+++ b/roles/pathagar/tasks/main.yml
@@ -1,8 +1,8 @@
 - name: Remove if exist pathagar rpm version
-  yum: name=pathagar state=absent
+  {{ ansible_pkg_mgr }} name=pathagar state=absent
 
 - name: Install pathagar pre requisites
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=latest
   with_items:
     - python-virtualenv

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install postgresql packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=present
   with_items:
     - postgresql

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -10,7 +10,7 @@
 
 # Install and configure samba server (requires ports 137, 138, 139, 445 open).
 - name: Ensure Samba-related packages are installed.
-  yum: pkg={{ item }} state=installed
+  {{ ansible_pkg_mgr }} pkg={{ item }} state=installed
   with_items:
   - samba
   - samba-client

--- a/roles/sugar-stats/tasks/main.yml
+++ b/roles/sugar-stats/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install sugar-stats required packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
     - sugar-stats-server

--- a/roles/sugar-stats/tasks/statistics-consolidation.yml
+++ b/roles/sugar-stats/tasks/statistics-consolidation.yml
@@ -1,5 +1,5 @@
 - name: Install python-pip package
-  yum: name=python-pip
+  {{ ansible_pkg_mgr }} name=python-pip
        state=installed
   tags: 
     - download
@@ -16,7 +16,7 @@
        extra_args="--no-index --find-links=file://{{ pip_packages_dir }}"
 
 - name: Install required libraries
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
     - rrdtool-python

--- a/roles/vnstat/tasks/main.yml
+++ b/roles/vnstat/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install required packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
     - vnstat

--- a/roles/xovis/tasks/main.yml
+++ b/roles/xovis/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install Couchdb and other necessary packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
     - couchdb

--- a/roles/xsce-admin/tasks/access.yml
+++ b/roles/xsce-admin/tasks/access.yml
@@ -1,5 +1,5 @@
 - name: Install textmode remote access packages
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=present
   with_items:
         - screen

--- a/roles/xsce-admin/tasks/cmdsrv.yml
+++ b/roles/xsce-admin/tasks/cmdsrv.yml
@@ -1,5 +1,5 @@
 - name: Install packages for cmdsrv
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
     - gcc

--- a/roles/xsce-admin/tasks/console.yml
+++ b/roles/xsce-admin/tasks/console.yml
@@ -1,5 +1,5 @@
 - name: Install packages for console
-  yum: name={{ item }}
+  {{ ansible_pkg_mgr }} name={{ item }}
        state=installed
   with_items:
     - mod_ssl


### PR DESCRIPTION
used cmdline for the change: 
for files in \`egrep roles/\*/tasks/\*.yml -e yum: | awk -F'[:]' '{print $1}\`; do  sed -e "s|yum:|{{ansible_pkg_mgr }}|" -i $files; done


ansible_pkg_mgr exists in F18 should be safe for this to merge, yum groupinstalls have not been altered. 