### PR TITLE
the test for 2.4 on centos fails

### DIFF
--- a/roles/awstats/templates/apache-awstats.conf
+++ b/roles/awstats/templates/apache-awstats.conf
@@ -24,20 +24,11 @@ ScriptAlias /awstats/ "/usr/share/awstats/wwwroot/cgi-bin/"
 <Directory "/usr/share/awstats/wwwroot">
     Options None
     AllowOverride None
-    <IfModule mod_authz_core.c>
-        # Apache 2.4	
         AuthType Basic
         AuthName "Admin Console"
         AuthBasicProvider external
         AuthExternal pwauth
         require valid-user
-    </IfModule>
-    <IfModule !mod_authz_core.c>
-        # Apache 2.2
-        Order allow,deny
-        Allow from 127.0.0.1
-        Allow from ::1
-    </IfModule>
 </Directory>
 # Additional Perl modules
 <IfModule mod_env.c>


### PR DESCRIPTION
I can go with admin-console which also just assumes apache 2.4 rather than 2.2