### PR TITLE
RFC move the default for xsce_domain to not be part of vars/*

### DIFF
--- a/roles/1-prep/defaults/main.yml
+++ b/roles/1-prep/defaults/main.yml
@@ -2,6 +2,7 @@
 installing: False
 
 #Set defaults for discovery process
+old_domain: "none"
 discovered_wan_iface: "none"
 discovered_lan_iface: "none"
 discovered_wireless_iface: "none"

--- a/roles/1-prep/tasks/detected_network.yml
+++ b/roles/1-prep/tasks/detected_network.yml
@@ -12,12 +12,12 @@
 - name: Setting prior domain name
   set_fact:
     xsce_domain: "{{ old_domain }}"
-  when: old_domain != "" and xsce_domain == ""
+  when: old_domain != "" and xsce_domain == "none"
 
 - name: Setting default XSCE domain name
   set_fact:
     xsce_domain: "lan"
-  when: xsce_domain == ""
+  when: xsce_domain == "none"
 
 # DETECT -- gateway and wireless
 - name: Get a list of slaves from previous config

--- a/roles/1-prep/tasks/detected_network.yml
+++ b/roles/1-prep/tasks/detected_network.yml
@@ -19,7 +19,7 @@
 - name: Setting default XSCE domain name
   set_fact:
     xsce_domain: "lan"
-  when: old_domain == "" and xsce_domain == "none"
+  when: old_domain == "none" and xsce_domain == "none"
 
 # DETECT -- gateway and wireless
 - name: Get a list of slaves from previous config

--- a/roles/1-prep/tasks/detected_network.yml
+++ b/roles/1-prep/tasks/detected_network.yml
@@ -6,8 +6,18 @@
 # above always registers
 - name: Checking for prior domain name
   set_fact:
-    xsce_domain: "{{ prior_domain.stdout }}"
-  when: prior_domain.stdout != "lan" and prior_domain.stdout != ""
+    old_domain: "{{ prior_domain.stdout }}"
+  when: prior_domain.stdout != ""
+
+- name: Setting prior domain name
+  set_fact:
+    xsce_domain: "{{ old_domain }}"
+  when: old_domain != "" and xsce_domain == ""
+
+- name: Setting default XSCE domain name
+  set_fact:
+    xsce_domain: "lan"
+  when: xsce_domain == ""
 
 # DETECT -- gateway and wireless
 - name: Get a list of slaves from previous config

--- a/roles/1-prep/tasks/detected_network.yml
+++ b/roles/1-prep/tasks/detected_network.yml
@@ -13,7 +13,7 @@
  name: Setting prior domain name
   set_fact:
     xsce_domain: "{{ old_domain }}"
-  when: old_domain != "" and xsce_domain == "none"
+  when: old_domain != "none" and xsce_domain == "none"
 
 # First pass and no user override
 - name: Setting default XSCE domain name

--- a/roles/1-prep/tasks/detected_network.yml
+++ b/roles/1-prep/tasks/detected_network.yml
@@ -206,6 +206,8 @@
             option='{{ item.option }}'
             value='{{ item.value }}'
   with_items:
+  - option: 'domain_name'
+    value: '{{ xsce_domain }}'
   - option: 'detected_gateway'
     value: '{{ discovered_wan_iface }}'
   - option: 'prior_gateway'

--- a/roles/1-prep/tasks/detected_network.yml
+++ b/roles/1-prep/tasks/detected_network.yml
@@ -9,15 +9,17 @@
     old_domain: "{{ prior_domain.stdout }}"
   when: prior_domain.stdout != ""
 
-- name: Setting prior domain name
+# ok user didn't override default and xs_domain_name exists use it.
+ name: Setting prior domain name
   set_fact:
     xsce_domain: "{{ old_domain }}"
   when: old_domain != "" and xsce_domain == "none"
 
+# First pass and no user override
 - name: Setting default XSCE domain name
   set_fact:
     xsce_domain: "lan"
-  when: xsce_domain == "none"
+  when: old_domain == "" and xsce_domain == "none"
 
 # DETECT -- gateway and wireless
 - name: Get a list of slaves from previous config

--- a/roles/3-base-server/tasks/main.yml
+++ b/roles/3-base-server/tasks/main.yml
@@ -1,11 +1,6 @@
 - name: Base Server Installed
   command: echo Base Server Installed
 
-- name: Restart xsce-cmdsrv service
-  service: name=xsce-cmdsrv
-           state=restarted
-  when: not installing
-
 - name: Restart httpd
   service: name=httpd
            state=restarted

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -147,6 +147,12 @@
   tags:
     - network
 
+#pre-populates xsce_domain correctly
+- name: Restart xsce-cmdsrv service
+  service: name=xsce-cmdsrv
+           state=restarted
+  when: not installing and not xsce_prepped
+
 - include: restart.yml
   when: not installing
   tags:

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -147,12 +147,6 @@
   tags:
     - network
 
-#pre-populates xsce_domain correctly
-- name: Restart xsce-cmdsrv service
-  service: name=xsce-cmdsrv
-           state=restarted
-  when: not installing and not xsce_prepped
-
 - include: restart.yml
   when: not installing
   tags:

--- a/runtags
+++ b/runtags
@@ -19,12 +19,16 @@ fi
 tags=$(echo $1 | tr "," "\n")
 
 found="N"
+restart="N"
 
 for tag in $tags
 do
   if [ "$tag" == "prep" ]
   then
     found="Y"
+  if [ "$tag" == "network" ]
+  then
+    restart="Y"
   fi
 
 done
@@ -47,3 +51,8 @@ if [ $# -ne 1 ]; then
 fi
 export ANSIBLE_LOG_PATH="xsce-debug.log"
 ansible-playbook -i ansible_hosts xsce.yml --connection=local --tags="""$taglist"""
+if [ "$restart" == "N" ]
+then
+    echo "Syncing xsce-cmdsrv"
+    systemctl -q is-enabled xsce-cmdsrv && systemctl restart xsce-cmdsrv
+fi

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -46,7 +46,7 @@ local_tz: "{{lookup ('env','TZ') }}"
 # Network Parameters
 
 xsce_hostname: schoolserver
-xsce_domain: lan
+xsce_domain:
 lan_ip: 172.18.96.1
 lan_netmask: 255.255.224.0
 

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -46,7 +46,7 @@ local_tz: "{{lookup ('env','TZ') }}"
 # Network Parameters
 
 xsce_hostname: schoolserver
-xsce_domain:
+xsce_domain: none
 lan_ip: 172.18.96.1
 lan_netmask: 255.255.224.0
 

--- a/vars/local_vars.yml
+++ b/vars/local_vars.yml
@@ -4,5 +4,9 @@
 #xsce_admin_user: xsce-admin
 
 # obtain a password hash with - python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")'
-#xsce_admin_passw_hash: 
+#xsce_admin_passw_hash:
+
+# set the domain name here
+#xsce_domain: lan
+
 


### PR DESCRIPTION
Seems like the cleanest way of dealing with setting the default value while providing a means to change the domain on the fly. What concerns me is config_vars, the gui type-over box for domain appears to be reading config_vars while the system state might be different from the gui's last run. Think it would it be better to have that box be populated  with the current state when the page is first opened, saves the user from having to set domain in two places.