### PR TITLE
Reconcile install

### DIFF
--- a/docs/VARIABLES.rst
+++ b/docs/VARIABLES.rst
@@ -17,27 +17,29 @@ Variable Files
 
 The vars directory holds two files, default_vars.yml and local_vars.yml.  The former holds
 the default values for a number of global variables for the installation.  The latter allows
-deployments to override these values.  Changes should not be made to default_vars.yml as they could
-be overwritten by a subsequent pull from the git repository.  The inital local_vars.yml file comes
-from the git repo but is marked not tracked on the first run, so edits will not be lost.  These
-parameters are either ones that a deployment may wish to override, such as xsce_domain, or global constants
-such as xsce_config_file.
+deployments to override these values.  These parameters are either ones that a deployment
+may wish to override, such as xsce_domain, or global constants.
+
+The inital local_vars.yml file comes from the git repo but is marked not tracked on the first run,
+so edits will not be lost, and is copied to /etc/xsce/local_vars.yml where it may be edited.
+Changes should not be made to default_vars.yml as they could be overwritten by a subsequent
+pull from the git repository.
 
 Variables Set in the Admin Console
 ==================================
 
-When installation is carried out using the Admin Console an additional variable file is used, /etc/xsce/config_vars.yml,
-which is set via a graphical user interface.  Values in this file further override values in default_vars.yml and 
-local_vars.yml files. It should be kept in mind that no changes are made to the original local_vars.yml file, so that
-if you go back to doing a manual install, none of the values entered in the Console will have any effect.  They can, however, 
-be copied from config_vars.yml to local_vars.yml.
+When installation is carried out using the Admin Console an additional variable file is populated, /etc/xsce/config_vars.yml,
+which is set via a graphical user interface.  Values in this file further override values in default_vars.yml and
+local_vars.yml files. It should be kept in mind that the order of precedence of the variables files is that config_vars.yml
+overrides local_vars.yml and local_vars.yml overrides default_vars.yml.  This is true whether the console is used to perform
+an install or one of the command line scripts.
 
 Computed or Derived Variables
 =============================
 
 After ansible has gathered its facts and loaded the variables files, it starts running roles in the order given in the top-level
 playbook.  For XSCE the first role is 1-prep. This role runs the local_facts module and then sets any variables that are
-derived from any of the above in computed_vars.yml.  For this reason the prep tag needs to be included any time an install 
+derived from any of the above in computed_vars.yml.  For this reason the prep tag needs to be included any time an install
 is done using tags only.
 
 Role Variables
@@ -77,7 +79,7 @@ Order of Execution and Precedence
 * Get ansible facts
 * Load default_vars.yml
 * Load local_vars.yml
-* Load config_vars.yml (if installing via the console)
+* Load config_vars.yml
 * Run local_facts script (part of 1-prep)
 * Run computed_vars.yml (part of 1-prep)
 * Load any vars particular to roles

--- a/install-console
+++ b/install-console
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-# if not the first run repo, location is here
+# copy var files to /etc/xsce for subsequent use
+
+./install-init
+
+# if not the first run, repo location is here
 
 if [ -f /etc/xsce/xsce.env ]
 then
@@ -27,7 +31,7 @@ then
 fi
 
 export ANSIBLE_LOG_PATH="xsce-install.log"
-ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local 
+ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local
 
 if [ -f /etc/selinux/config ]
 then

--- a/install-init
+++ b/install-init
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# if not the first run, repo location is here
+
+if [ -f /etc/xsce/xsce.env ]
+then
+  . /etc/xsce/xsce.env
+  cd $XSCE_DIR
+fi
+
+if [ ! -f xsce.yml ]
+then
+ echo "XSCE Playbook not found."
+ echo "Please run this command from the top level of the git repo."
+ echo "Exiting."
+ exit
+fi
+
+PLAYBOOK="install-init.yml"
+INVENTORY="ansible_hosts"
+
+export ANSIBLE_LOG_PATH="xsce-install.log"
+ansible-playbook -i $INVENTORY $PLAYBOOK --connection=local

--- a/install-init.yml
+++ b/install-init.yml
@@ -1,0 +1,49 @@
+---
+- hosts: all
+  sudo: yes
+
+# The var files read or included here are not needed, but might be in the future
+
+  vars_files:
+  - vars/default_vars.yml
+
+  tasks:
+
+  - include_vars: "{{ item }}"
+    with_first_found:
+     - /etc/xsce/local_vars.yml
+     - vars/local_vars.yml
+
+  - name: Create /etc/xsce
+    file: path=/etc/xsce
+          owner=root
+          group=root
+          mode=0755
+          state=directory
+
+  - name: See if default config_vars.yml exists
+    stat: path=/etc/xsce/config_vars.yml
+    register: config_vars
+
+  - name: Install default config_vars.yml
+    template: src=roles/xsce-admin/templates/cmdsrv/config_vars.yml
+              dest=/etc/xsce/config_vars.yml
+              owner=root
+              group=root
+              mode=0644
+    when: config_vars.stat.exists == false
+
+  - name: See if default local_vars.yml exists
+    stat: path=/etc/xsce/local_vars.yml
+    register: local_vars
+
+  - name: Install default local_vars.yml
+    copy: src=vars/local_vars.yml
+          dest=/etc/xsce/local_vars.yml
+          owner=root
+          group=root
+          mode=0644
+    when: local_vars.stat.exists == false
+
+  - name: Install Initionalization Complete
+    command: echo Install Initionalization Complete

--- a/runansible
+++ b/runansible
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-# if not the first, run repo location is here
+# copy var files to /etc/xsce for subsequent use
+
+./install-init
+
+# if not the first run, repo location is here
 
 if [ -f /etc/xsce/xsce.env ]
 then
@@ -24,7 +28,7 @@ echo "Running local playbooks! "
 XSDOMAIN=""
 
 # Pass in Existing Domain
-if [ -f /etc/sysconfig/xs_domain_name ] 
+if [ -f /etc/sysconfig/xs_domain_name ]
 then
  XSDOMAIN=`cat /etc/sysconfig/xs_domain_name`
 fi
@@ -40,10 +44,10 @@ if [ x"$XSDOMAIN" != x ]
 then
  ARGS="--extra-vars '{\"xsce_domain\":\"$XSDOMAIN\"}'"
 else
- ARGS="" 
+ ARGS=""
 fi
 
 export ANSIBLE_LOG_PATH="xsce-install.log"
 ansible -m setup -i $INVENTORY localhost --connection=local >> /dev/null
 
-ansible-playbook -i $INVENTORY $PLAYBOOK ${ARGS} --connection=local 
+ansible-playbook -i $INVENTORY $PLAYBOOK ${ARGS} --connection=local

--- a/runtags
+++ b/runtags
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# copy var files to /etc/xsce for subsequent use
+
+./install-init
+
 # if not the first run, repo location is here
 
 if [ -f /etc/xsce/xsce.env ]

--- a/xsce-base.yml
+++ b/xsce-base.yml
@@ -4,7 +4,8 @@
 
   vars_files:
   - vars/default_vars.yml
-  - vars/local_vars.yml
+  - /etc/xsce/local_vars.yml
+  - /etc/xsce/config_vars.yml
 
   roles:
       - { role: 0-once, tags: ['once','platform','base'] }

--- a/xsce-from-console.yml
+++ b/xsce-from-console.yml
@@ -4,7 +4,7 @@
 
   vars_files:
   - vars/default_vars.yml
-  - vars/local_vars.yml
+  - /etc/xsce/local_vars.yml
   - /etc/xsce/config_vars.yml
 
   roles:
@@ -13,6 +13,6 @@
       - { role: 4-server-options, tags: ['options'] }
       - { role: 5-xo-services, tags: ['xo-services'] }
       - { role: 6-generic-apps, tags: ['generic-apps'] }
-      - { role: 7-edu-apps, tags: ['edu-apps'] }    
+      - { role: 7-edu-apps, tags: ['edu-apps'] }
       - { role: 8-mgmt-tools, tags: ['tools'] }
-      - { role: 9-local-addons, tags: ['addons'] }      
+      - { role: 9-local-addons, tags: ['addons'] }

--- a/xsce.yml
+++ b/xsce.yml
@@ -4,7 +4,8 @@
 
   vars_files:
   - vars/default_vars.yml
-  - vars/local_vars.yml
+  - /etc/xsce/local_vars.yml
+  - /etc/xsce/config_vars.yml
 
   roles:
       - { role: 0-once, tags: ['once','platform','base'] }
@@ -14,6 +15,6 @@
       - { role: 4-server-options, tags: ['options'] }
       - { role: 5-xo-services, tags: ['xo-services'] }
       - { role: 6-generic-apps, tags: ['generic-apps'] }
-      - { role: 7-edu-apps, tags: ['edu-apps'] }    
+      - { role: 7-edu-apps, tags: ['edu-apps'] }
       - { role: 8-mgmt-tools, tags: ['tools'] }
-      - { role: 9-local-addons, tags: ['addons'] }      
+      - { role: 9-local-addons, tags: ['addons'] }


### PR DESCRIPTION
create install-init script and playbook to set up var files before subsequent scripts
call install-init at the beginning of runansbile, runtags, and install-console
change top level playbooks to use local_vars from /etc/xsce
change top level playbooks to add config_vars from /etc/xsce
fix a few syntax errors in comments
remove some trailing blanks