### PR TITLE
remove the B --background parameter in a unit file, which must do the…

### DIFF
--- a/roles/network/templates/hostapd/hostapd.service.j2
+++ b/roles/network/templates/hostapd/hostapd.service.j2
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 Type=idle
 PIDFile=/run/hostapd.pid
-ExecStart=/usr/sbin/hostapd -B  -P /run/hostapd.pid /etc/hostapd/hostapd.conf
+ExecStart=/usr/sbin/hostapd  -P /run/hostapd.pid /etc/hostapd/hostapd.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
… backgrounding itself -- doing double confuses its following pid