### PR TITLE
The include_vars module does not like an empty vars file (all comment…

### DIFF
--- a/vars/local_vars.yml
+++ b/vars/local_vars.yml
@@ -5,4 +5,4 @@
 
 # obtain a password hash with - python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")'
 #xsce_admin_passw_hash: 
-
+varible: value


### PR DESCRIPTION
…s), so add a dummy variable to local_vars