### PR TITLE
Ensure HWADDR is present in ifcfg-WAN

### DIFF
--- a/roles/network/tasks/edit_ifcfg.yml
+++ b/roles/network/tasks/edit_ifcfg.yml
@@ -27,6 +27,13 @@
               regexp="NAME"
               dest=/etc/sysconfig/network-scripts/ifcfg-WAN
 
+- name: Ensure macaddress is present 
+  lineinfile: state=present
+              backrefs=yes
+              regexp="HWADDR"
+              line="HWADDR="{{ hostvars[inventory_hostname]['ansible_' + xsce_wan_iface]['macaddress'] }}"
+              dest=/etc/sysconfig/network-scripts/ifcfg-WAN
+
 - name: add marker
   lineinfile: state=present
               line="# Modified by XSCE"


### PR DESCRIPTION
Ran across this with Anish, CentOS and pre-exixting ifcfg file that was renamed. Need to make sure the regexps are working in edit_ifcfg.yml