### PR TITLE
pathagar - split django-taggit to have '--use-wheel' in the cmdline

### DIFF
--- a/roles/pathagar/tasks/main.yml
+++ b/roles/pathagar/tasks/main.yml
@@ -59,8 +59,15 @@
     - Django==1.4.5
     - django-tagging==0.3.1
     - django-sendfile==0.3.6
-    - django-taggit==0.10
     - lxml==3.4.4
+
+- name: Install pathagar requirements in a virtualenv
+  pip: name={{ item }}
+       extra_args="--use-wheel --no-index --find-links=file://{{ pip_packages_dir }}"
+       virtualenv={{ pathagar_venv }}
+       virtualenv_site_packages=yes
+  with_items:
+    - django-taggit==0.10
 
 - name: Create pathagar postgresql user
   postgresql_user: name={{ pathagar_db_user }}

--- a/roles/pathagar/tasks/main.yml
+++ b/roles/pathagar/tasks/main.yml
@@ -44,7 +44,7 @@
     - Django==1.4.5
     - django-tagging==0.3.1
     - django-sendfile==0.3.6
-    - django-taggit==0.10
+    - django-taggit==0.14
     - lxml==3.4.4
   when: not {{ use_cache }} and not {{ no_network }}
   tags:
@@ -67,7 +67,7 @@
        virtualenv={{ pathagar_venv }}
        virtualenv_site_packages=yes
   with_items:
-    - django-taggit==0.10
+    - django-taggit==0.14
 
 - name: Create pathagar postgresql user
   postgresql_user: name={{ pathagar_db_user }}


### PR DESCRIPTION
Fixes install failure found while testing on CentOS