### PR TITLE
kalite - don't try to git clone twice

### DIFF
--- a/roles/kalite/tasks/enable.yml
+++ b/roles/kalite/tasks/enable.yml
@@ -29,7 +29,8 @@
             section=kalite
             option='{{ item.option }}'
             value='{{ item.value }}'
-    - option: enabled
-      value: "{{ kalite_enabled }}"
-    - option: cron_enabled
-      value: "{{ kalite_cron_enabled }}"
+  with_items:
+    - option: 'enabled'
+      value: '{{ kalite_enabled }}'
+    - option: 'cron_enabled'
+      value: '{{ kalite_cron_enabled }}'

--- a/roles/kalite/tasks/enable.yml
+++ b/roles/kalite/tasks/enable.yml
@@ -23,3 +23,13 @@
            enabled=yes
            state=started
   when: kalite_cron_enabled
+
+- name: Add kalite to service list
+  ini_file: dest='{{ service_filelist }}'
+            section=kalite
+            option='{{ item.option }}'
+            value='{{ item.value }}'
+    - option: enabled
+      value: "{{ kalite_enabled }}"
+    - option: cron_enabled
+      value: "{{ kalite_cron_enabled }}"

--- a/roles/kalite/tasks/enable.yml
+++ b/roles/kalite/tasks/enable.yml
@@ -1,15 +1,3 @@
-- name: Create kalite service(s) and support scripts
-  template: backup=yes
-            src={{ item.src }}
-            dest={{ item.dest }}
-            owner=root
-            group=root
-            mode={{ item.mode }}
-  with_items:
-    - { src: 'kalite-serve.service.j2', dest: '/etc/systemd/system/kalite-serve.service', mode: '0655'}
-    - { src: 'kalite-cron.service.j2', dest: '/etc/systemd/system/kalite-cron.service', mode: '0655'}
-    - { src: 'xsce_cronservectl.sh.j2', dest: '{{ kalite_root }}/scripts/xsce_cronservectl.sh', mode: '0755'}
-
 - name: Disable kalite server
   service: name=kalite-serve
            enabled=no

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -12,7 +12,7 @@
        dest={{ downloads_dir }}/ka-lite
        depth=1
        version="0.13.x"
-  when: not {{ use_cache }}
+  when: not {{ use_cache }} and not kalite_installed.stat.exists == True
   tags:
     - download2
 
@@ -57,6 +57,23 @@
             owner={{ kalite_user }}
             group={{ kalite_user }}
             mode=644
+
+- name: Add kalite to service list
+  ini_file: dest='{{ service_filelist }}'
+            section=kalite
+            option='{{ item.option }}'
+            value='{{ item.value }}'
+  with_items:
+    - option: name
+      value: kalite
+    - option: description
+      value: '"KA-Lite is a server to present Khan Academy videos offline and to download them."'
+    - option: path
+      value: "{{ kalite_root }}"
+    - option: server_name
+      value: "{{ kalite_server_name }}"
+    - option: port
+      value: "{{ kalite_server_port }}"
 
 - name: Run the install using kalite manage
   command: "/usr/bin/su {{ kalite_user }} -c '{{ kalite_root }}/bin/kalite manage setup --username={{ kalite_user }} --password={{ kalite_password }} --noinput'"

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -64,16 +64,16 @@
             option='{{ item.option }}'
             value='{{ item.value }}'
   with_items:
-    - option: name
-      value: kalite
-    - option: description
+    - option: 'name'
+      value: 'kalite'
+    - option: 'description'
       value: '"KA-Lite is a server to present Khan Academy videos offline and to download them."'
-    - option: path
-      value: "{{ kalite_root }}"
-    - option: server_name
-      value: "{{ kalite_server_name }}"
-    - option: port
-      value: "{{ kalite_server_port }}"
+    - option: 'path'
+      value: '{{ kalite_root }}'
+    - option: 'server_name'
+      value: '{{ kalite_server_name }}'
+    - option: 'port'
+      value: '{{ kalite_server_port }}'
 
 - name: Run the install using kalite manage
   command: "/usr/bin/su {{ kalite_user }} -c '{{ kalite_root }}/bin/kalite manage setup --username={{ kalite_user }} --password={{ kalite_password }} --noinput'"

--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -1,3 +1,21 @@
+- name: Install dependent packages
+  yum: name={{ item }}
+       state=installed
+  with_items:
+    - python-psutil
+    - expect
+  tags:
+    - download
+
+- name: Download the latest kalite repo
+  git: repo={{ kalite_repo_url }}
+       dest={{ downloads_dir }}/ka-lite
+       depth=1
+       version="0.13.x"
+  when: not {{ use_cache }}
+  tags:
+    - download2
+
 - name: Create xsce-kalite user and password
   user: name={{ kalite_user }}
         password={{ kalite_password_hash }}
@@ -19,6 +37,18 @@
         group={{ kalite_user }}
         recurse=yes
         state=directory
+
+- name: Create kalite service(s) and support scripts
+  template: backup=yes
+            src={{ item.src }}
+            dest={{ item.dest }}
+            owner=root
+            group=root
+            mode={{ item.mode }}
+  with_items:
+    - { src: 'kalite-serve.service.j2', dest: '/etc/systemd/system/kalite-serve.service', mode: '0655'}
+    - { src: 'kalite-cron.service.j2', dest: '/etc/systemd/system/kalite-cron.service', mode: '0655'}
+    - { src: 'xsce_cronservectl.sh.j2', dest: '{{ kalite_root }}/scripts/xsce_cronservectl.sh', mode: '0755'}
 
 # local_settings is deprecated
 - name: Copy local_settings file

--- a/roles/kalite/tasks/main.yml
+++ b/roles/kalite/tasks/main.yml
@@ -1,29 +1,10 @@
 - name: See if kalite is installed
   stat: path="{{ kalite_root }}/kalite/database/data.sqlite"
   register: kalite_installed
+  tags:
+    - download2
 
 - include: install.yml
   when: not kalite_installed.stat.exists == True
 
 - include: enable.yml
-
-- name: Add kalite to service list
-  ini_file: dest='{{ service_filelist }}'
-            section=kalite
-            option='{{ item.option }}'
-            value='{{ item.value }}'
-  with_items:
-    - option: name
-      value: kalite
-    - option: description
-      value: '"KA-Lite is a server to present Khan Academy videos offline and to download them."'
-    - option: path
-      value: "{{ kalite_root }}"
-    - option: server_name
-      value: "{{ kalite_server_name }}"
-    - option: port
-      value: "{{ kalite_server_port }}"
-    - option: enabled
-      value: "{{ kalite_enabled }}"
-    - option: cron_enabled
-      value: "{{ kalite_cron_enabled }}"

--- a/roles/kalite/tasks/main.yml
+++ b/roles/kalite/tasks/main.yml
@@ -1,21 +1,3 @@
-- name: Install dependent packages
-  yum: name={{ item }}
-       state=installed
-  with_items:
-    - python-psutil
-    - expect
-  tags:
-    - download
-
-- name: Download the latest kalite repo
-  git: repo={{ kalite_repo_url }}
-       dest={{ downloads_dir }}/ka-lite
-       depth=1
-       version="0.13.x"
-  when: not {{ use_cache }}
-  tags:
-    - download2
-
 - name: See if kalite is installed
   stat: path="{{ kalite_root }}/kalite/database/data.sqlite"
   register: kalite_installed


### PR DESCRIPTION
don't try to git clone twice, observed failure where the git repo is already present.
templates to install, could stay if we're looking to change port numbers on the fly.
run yum install based on data.sqlite's presence, for some speed 