### PR TITLE
stat detect not working as intended

### DIFF
--- a/roles/1-prep/tasks/detected_network.yml
+++ b/roles/1-prep/tasks/detected_network.yml
@@ -26,7 +26,7 @@
 - name: Setting has_WAN
   set_fact:
     has_WAN: "True"
-  when: has_ifcfg_WAN.stat.exists
+  when: has_ifcfg_WAN.stat.exists is defined and has_ifcfg_WAN.stat.exists
 
 # unused
 # DETECT -- gateway and wireless
@@ -67,7 +67,7 @@
 - name: Setting has_ifcfg_gw based on device if found
   set_fact:
     has_ifcfg_gw: "{{ item|trim }}"
-  when: ifcfg_gw_device is defined and item|trim != "" and item|trim != "/etc/sysconfig/network-scripts/ifcfg-LAN"
+  when: ifcfg_gw_device.stdout_lines is defined and item|trim != "" and item|trim != "/etc/sysconfig/network-scripts/ifcfg-LAN"
   with_items:
       - "{{ ifcfg_gw_device.stdout_lines }}"
 


### PR DESCRIPTION
Jerry,

It's a long story. 
I forgot that my AP with ssid:"George's Time Capsule" gives our code fits because of the apostrophe. NM created an ifcfg for it, and runtags network burped on the apostrophe.

So I deleted the ifcfg file, associated with another AP, and rantags network. The comments suggest that checking for a file was your intent, but it did not work because the variable you tested was not defined.

Hence this PR. I can help chip at the tests, even if I cannot see the larger picture