### PR TITLE
add teamviewer to default_vars with install disabled by default

### DIFF
--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -223,6 +223,10 @@ watchdog:
   - postgresql
   - squid
 
+# teamviewer
+teamviewer_install: False
+teamviewer_enabled: False
+
 # vnstat
 vnstat_install: True
 vnstat_enabled: False


### PR DESCRIPTION
Missing from default_vars