### PR TITLE
TimeZone handling during install

### DIFF
--- a/roles/2-common/tasks/prelim.yml
+++ b/roles/2-common/tasks/prelim.yml
@@ -18,3 +18,7 @@
            enabled=yes
   with_items:
     - sshd
+
+- name: Set default Timezone
+  shell: ln -sf /usr/share/zoneinfo/{{ xsce_TZ }} /etc/localtime
+  when xsce_TZ is defined and xsce_TZ != ""


### PR DESCRIPTION
This will allow optionally  setting the timezone from local_vars.yml with an entry such as 
xsce_TZ: America/New_York during install-console or runansible