### PR TITLE
Net nov12 - feedback please

### DIFF
--- a/roles/network/tasks/computed_network.yml
+++ b/roles/network/tasks/computed_network.yml
@@ -30,10 +30,10 @@
 # we need to have an interface name for ifcfg-WAN to be able to change gateway
 # the DEVICE from the gui. Thanks to George for proving my point about knowing
 # what device to switch to.
-- name: Using GUI_WAN info
-  set_fact:
-    user_wan_iface: "{{ gui_wan_iface }}"
-  when: gui_wan_iface != "unset" and gui_desired_network_role is defined and gui_desired_network_role != "LanController"
+#- name: Using GUI_WAN info
+#  set_fact:
+#    user_wan_iface: "{{ gui_wan_iface }}"
+#  when: gui_wan_iface != "unset" and gui_desired_network_role is defined and gui_desired_network_role != "LanController"
 
 # should make the GUI buttons the last call
 - name: Checking xsce_wan_enabled

--- a/roles/network/tasks/ifcfg_mods.yml
+++ b/roles/network/tasks/ifcfg_mods.yml
@@ -60,7 +60,7 @@
 
 # test point, we should always have one with any kind of starting point
 # no ifcfg = supply
-# had but not WAN = rename and edit.
+# had but not WAN = rename and edit if wired, skip wifi gateway.
 # test point, confirm onboot=no is OK everywhere
 
 - name: Enabling pre-existing ifcfg-WAN file

--- a/roles/network/tasks/ifcfg_mods.yml
+++ b/roles/network/tasks/ifcfg_mods.yml
@@ -9,11 +9,6 @@
   changed_when: False
   when: xsce_prepped and (num_lan_interfaces != "0" or xsce_wireless_lan_iface != "none")
 
-# move gateway if not WAN
-# might have wifi info if wireless is used as uplink.
-- include: edit_ifcfg.yml
-  when: has_ifcfg_gw != "none" and has_ifcfg_gw != "/etc/sysconfig/network-scripts/ifcfg-WAN"
-
 # clear all bridge ifcfg files
 - name: Now delete slave bridge ifcfg files
   shell: rm -f /etc/sysconfig/network-scripts/ifcfg-"{{ item }}"
@@ -24,6 +19,11 @@
 ## vars/ users should set user_wan_iface to avoid messy redetect
 - include: redetect.yml
   when: discovered_wan_iface == "none" and user_wan_iface == "auto"
+
+# move gateway if not WAN
+# might have wifi info if wireless is used as uplink.
+- include: edit_ifcfg.yml
+  when: has_wifi_gw == "none" and has_ifcfg_gw != "none" and has_ifcfg_gw != "/etc/sysconfig/network-scripts/ifcfg-WAN"
 
 # create ifcfg-WAN if missing
 # if we get here we have gateway but no ifcfg file

--- a/roles/network/tasks/redetect.yml
+++ b/roles/network/tasks/redetect.yml
@@ -70,12 +70,12 @@
   when: dhcp_wifi_results.stdout is defined and dhcp_wifi_results.stdout != ""
 
 - name: interface list
-  shell: ls /sys/class/net | grep -v -e lo
+  shell: ls /sys/class/net | grep -v -e lo -e br
   register: adapter_list
 
 # discovered_wireless_iface might need work
 - name: Try dhcp on all wired devices 
-  shell: nmcli d connect "{{ item|trim }}"
+  shell: nmcli d connect {{ item|trim }}
   when: item|trim != discovered_wireless_iface and item|trim != xsce_wireless_lan_iface and not dhcp_good
   with_items:
       - "{{ adapter_list.stdout_lines }}"

--- a/roles/network/tasks/redetect.yml
+++ b/roles/network/tasks/redetect.yml
@@ -73,6 +73,11 @@
   shell: ls /sys/class/net | grep -v -e lo -e br
   register: adapter_list
 
+# monitor-connection-files defaults to no with F21, F18-F20 defaults to yes
+- name: Reloading nmcli for deleted files
+  shell: nmcli con reload
+  when: not installing and not no_NM_reload
+
 # discovered_wireless_iface might need work
 - name: Try dhcp on all wired devices 
   shell: nmcli d connect {{ item|trim }}

--- a/roles/network/tasks/redetect.yml
+++ b/roles/network/tasks/redetect.yml
@@ -70,7 +70,7 @@
   when: dhcp_wifi_results.stdout is defined and dhcp_wifi_results.stdout != ""
 
 - name: interface list
-  shell: ls /sys/class/net | grep -v -e lo -e br
+  shell: ls /sys/class/net | grep -v -e lo -e br -e tun
   register: adapter_list
 
 # monitor-connection-files defaults to no with F21, F18-F20 defaults to yes


### PR DESCRIPTION
3 points 
1. redetect.yml needs edit_ifcfg.yml to rename has_ifcfg_gw to be xsce-WAN. think0 on my part.
2. call nmcli c reload to clear out deleted files from memory before re-detection. should make this part much more robust.
3. user_wan_iface needs to be auto for redetect.yml to occur. Might be better to alter 1-prep for  gui_wan_iface?
