### PR TITLE
install-init changes

### DIFF
--- a/install-init
+++ b/install-init
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# Mark local_vars as do not track to preserve local changes
-
-git update-index --assume-unchanged vars/local_vars.yml
-
 # the playbook does nothing if the following already exists so exit
 
 if [ -f /etc/xsce/config_vars.yml ]
@@ -18,6 +14,9 @@ then
  echo "Exiting."
  exit 1
 fi
+
+# Mark local_vars as do not track to preserve local changes
+git update-index --assume-unchanged vars/local_vars.yml
 
 PLAYBOOK="install-init.yml"
 INVENTORY="ansible_hosts"

--- a/install-init
+++ b/install-init
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-# if not the first run, repo location is here
+# Mark local_vars as do not track to preserve local changes
 
-if [ -f /etc/xsce/xsce.env ]
+git update-index --assume-unchanged vars/local_vars.yml
+
+# the playbook does nothing if the following already exists so exit
+
+if [ -f /etc/xsce/config_vars.yml ]
 then
-  . /etc/xsce/xsce.env
-  cd $XSCE_DIR
+  exit 0
 fi
 
 if [ ! -f xsce.yml ]
@@ -13,7 +16,7 @@ then
  echo "XSCE Playbook not found."
  echo "Please run this command from the top level of the git repo."
  echo "Exiting."
- exit
+ exit 1
 fi
 
 PLAYBOOK="install-init.yml"

--- a/install-init
+++ b/install-init
@@ -7,7 +7,7 @@ then
   exit 0
 fi
 
-if [ ! -f xsce.yml ]
+if [ ! -f install-init.yml ]
 then
  echo "XSCE Playbook not found."
  echo "Please run this command from the top level of the git repo."

--- a/roles/0-once/templates/local_facts.fact.j2
+++ b/roles/0-once/templates/local_facts.fact.j2
@@ -9,9 +9,6 @@ UUID=`cat /etc/xsce/uuid`
 
 cd $XSCE_DIR
 
-# while we're here untrack local vars
-git update-index --assume-unchanged vars/local_vars.yml
-
 # get current version
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 COMMIT=`git rev-parse --verify HEAD`

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -58,7 +58,7 @@ adm_cons_allow_downloads: False
 # Values are used if there is an internal wifi adapter and hostapd is enabled
 # The platform variable adapts install to specific hardware (raspberry pi=rpi2)
 hostapd_enabled: True
-host_ssid: "XSCE"
+host_ssid: "Internet in a Box"
 host_wifi_mode: g
 host_channel: 6
 


### PR DESCRIPTION
only run if /etc/xsce/config_vars.yml doesn't exist
add don't track (used to be here, but disappeared sometime)