### PR TITLE
Adams install-console fix

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -71,7 +71,7 @@
 - name: Supply wan interface file
   template: src=network/ifcfg-WAN.j2
             dest=/etc/sysconfig/network-scripts/ifcfg-WAN
-  when: 'xsce_wan_iface != "none" and wan_ip != "dhcp"'
+  when: 'xsce_wan_iface != "none" and wan_ip != "dhcp"' and not gui_static_wan is defined
 
 - include: NM.yml
   when: 'ansible_distribution_version <= "20" and wan_ip != "dhcp"'

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -71,22 +71,22 @@
 - name: Supply wan interface file
   template: src=network/ifcfg-WAN.j2
             dest=/etc/sysconfig/network-scripts/ifcfg-WAN
-  when: 'xsce_wan_iface != "none" and wan_ip != "dhcp"' and not gui_static_wan is defined
+  when: xsce_wan_iface != "none" and wan_ip != "dhcp"' and not gui_static_wan is defined
 
 - include: NM.yml
-  when: 'ansible_distribution_version <= "20" and wan_ip != "dhcp"'
+  when: ansible_distribution_version <= "20" and wan_ip != "dhcp"
 
 - name: Re-read network config files
-  shell: 'nmcli con reload'
+  shell: nmcli con reload
   ignore_errors: yes
-  when: 'ansible_distribution_version >= "21" and wan_ip != "dhcp"'
+  when: ansible_distribution_version >= "21" and wan_ip != "dhcp"
 
 - name: use upstream nameserver until named is installed
   lineinfile: dest=/etc/resolv.conf
               line='nameserver {{wan_nameserver}}'
               create=yes
               state=present
-  when: 'xsce_wan_iface != "none" and wan_ip != "dhcp"'
+  when: xsce_wan_iface != "none" and wan_ip != "dhcp"
 
 ##### End static ip address info
 

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -71,7 +71,7 @@
 - name: Supply wan interface file
   template: src=network/ifcfg-WAN.j2
             dest=/etc/sysconfig/network-scripts/ifcfg-WAN
-  when: xsce_wan_iface != "none" and wan_ip != "dhcp"' and not gui_static_wan is defined
+  when: xsce_wan_iface != "none" and wan_ip != "dhcp" and not gui_static_wan is defined
 
 - include: NM.yml
   when: ansible_distribution_version <= "20" and wan_ip != "dhcp"


### PR DESCRIPTION
This point of the code was designed to be used early to bring up the network before yum was run, and may be out of place in the scheme of things now. For this to really work as intended network would need to move to just after 1-prep in install-console. For now just skip supplying the WAN file at this point as there is additional logic later dealing with gui_static_wan in computed_network.yml