### PR TITLE
setting prepped when no domain change defeats install

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -37,11 +37,6 @@
     - network
     - domain
 
-- name: Domain name did not change setting xsce_prepped
-  set_fact: 
-    xsce_prepped: True
-  when: not domainname.changed
-
 #TODO: Use vars instead of hardcoded values
 - name: Configure /etc/hosts with LAN
   lineinfile: dest=/etc/hosts


### PR DESCRIPTION
Initially, I didn't have the USB wifi installed and I got Appliance mode. Then I inserted the wifi, and ran "./runtags network". The gateway functions named, squid, dansguardian, etc did not load, (though gateway was properly sensed). -- on an XO1.5 with current master