### PR TITLE
cmdsrv - correct syntax for 'creates'

### DIFF
--- a/roles/xsce-admin/tasks/cmdsrv.yml
+++ b/roles/xsce-admin/tasks/cmdsrv.yml
@@ -40,8 +40,9 @@
     - download2
 
 - name: Install php binding for zeromq
-  shell: yes '' | pecl install zmq*tgz
-         creates="{{ phplib_dir }}/modules/zmq.so"
+  shell: pecl install -f zmq*tgz
+  args:
+    creates: "{{ phplib_dir }}/modules/zmq.so"
 
 - name: Download speedtest-cli
   pip: name=speedtest-cli


### PR DESCRIPTION
Fix for compile failure noted in #538 test with runtags xsce-admin with and without so file present
http://paste.fedoraproject.org/302745/50449116
present
```
2015-12-18 07:18:06,158 p=17352 u=root |  TASK: [xsce-admin | Install php binding for zeromq] ***************************
2015-12-18 07:18:06,696 p=17352 u=root |  ok: [127.0.0.1]
```
absent
```
2015-12-18 07:22:08,443 p=18753 u=root |  TASK: [xsce-admin | Install php binding for zeromq] ***************************
2015-12-18 07:22:39,313 p=18753 u=root |  changed: [127.0.0.1]
```

note the OK and CHANGED between the two