### PR TITLE
cause the macro to not exist for exclude docs

### DIFF
--- a/roles/0-once/tasks/xo.yml
+++ b/roles/0-once/tasks/xo.yml
@@ -22,8 +22,7 @@
   lineinfile: backup=yes
               dest=/etc/rpm/macros.imgcreate
               regexp='^%_excludedocs'
-              line='%_excludedocs 0'
-              state=present
+              state=absent
 
 - name: pre(re)-Install packages
   yum: name={{ item }}


### PR DESCRIPTION
experience suggests that the mere existence of the macro disables docs on the XO series