### PR TITLE
get awastats to be like every other http service -- callable vin http…

### DIFF
--- a/roles/awstats/templates/apache-awstats.conf
+++ b/roles/awstats/templates/apache-awstats.conf
@@ -16,14 +16,16 @@ Alias /awstatsclasses "/usr/share/awstats/wwwroot/classes/"
 Alias /awstatscss "/usr/share/awstats/wwwroot/css/"
 Alias /awstatsicons "/usr/share/awstats/wwwroot/icon/"
 ScriptAlias /awstats/ "/usr/share/awstats/wwwroot/cgi-bin/"
+ScriptAlias /awstats "/usr/share/awstats/wwwroot/"
 
 
 #
 # This is to permit URL access to scripts/files in AWStats directory.
 #
 <Directory "/usr/share/awstats/wwwroot">
-    Options None
+    Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
     AllowOverride None
+    DirectoryIndex awstats.pl
         AuthType Basic
         AuthName "Admin Console"
         AuthBasicProvider external


### PR DESCRIPTION
…://schoolserver.lan/awstats. This seemes to work as desired. Trial and error got me to this, and I cannot claim to understand what it is doing, or why it works. (maybe since it's a cleanup thing, it should  wait for 6.1)