### PR TITLE
Dokuwiki | Update url in roles/dokuwiki/defaults

### DIFF
--- a/roles/dokuwiki/defaults/main.yml
+++ b/roles/dokuwiki/defaults/main.yml
@@ -1,4 +1,4 @@
-dokuwiki_url: /wiki
+dokuwiki_url: /dokuwiki
 dokuwiki_install: True
 dokuwiki_enabled: False
 dokuwiki_version: "dokuwiki-2014-09-29.tgz"


### PR DESCRIPTION
Update the default url of dokuwiki in playbook to /dokuwiki from /wiki to be consistent with the entry in xsce-homepage.conf