### PR TITLE
Revert "revise the released branch name"

### DIFF
--- a/installer/livecd/Fedora-22/ks.cfg
+++ b/installer/livecd/Fedora-22/ks.cfg
@@ -36,7 +36,7 @@ mkdir -p /opt/schoolserver
 cd /opt/schoolserver
 
 ### release flow
-git clone --depth 1 --branch stable https://github.com/XSCE/xsce 
+git clone --depth 1 --branch release-6.0 https://github.com/XSCE/xsce 
 cd xsce
 
 # pre-seed master so the same commit hash is in both branches for a common 
@@ -108,7 +108,7 @@ EOF
 git reset --hard 
 
 # switch back to the release branch
-git checkout stable
+git checkout release-6.0
 
 #disable updates-testing
 sed -i 's|enabled=1|enabled=0|' /etc/yum.repos.d/fedora-updates-testing.repo


### PR DESCRIPTION
This reverts commit 33fe74e1ee9325622850e63b539408aa9c0c5b7a. which was used as a demonstration of the problem of using tags without an underlying branch in git  