### PR TITLE
fix rtc device example as must be lower case

### DIFF
--- a/roles/1-prep/tasks/hw_discovery.yml
+++ b/roles/1-prep/tasks/hw_discovery.yml
@@ -1,6 +1,6 @@
 ##  DISCOVER ADAPTERS   ######
-# If an rtc is included in a raspberry pi device the user must identify it in 
-# vars/local_vars.yml via a declaration similar to "rtc_id: DS3231"
+# If an rtc is included in a raspberry pi device the user must identify it in
+# vars/local_vars.yml via a declaration similar to "rtc_id: ds3231" (lower case required)
 #
 # Note that raspberry pi cpu discovery occurs in roles/0-prep/tasks/main.yml
 

--- a/roles/1-prep/tasks/raspberry_pi_2.yml
+++ b/roles/1-prep/tasks/raspberry_pi_2.yml
@@ -14,7 +14,7 @@
             dest=/etc/udev/rules.d/92-rtc-i2c.rule
             owner:root
             group:root
-            mode:0755
+            mode:0644
   when: rtc_id != "none"
 
 - name: Reboot if the config.txt was changed


### PR DESCRIPTION
change permissions on udev rtc rule