### PR TITLE
correct internet test proxy issue by replacing wget with get_url

### DIFF
--- a/roles/1-prep/defaults/main.yml
+++ b/roles/1-prep/defaults/main.yml
@@ -11,6 +11,7 @@ strict_networking: False
 xsce_demo_mode: False
 gw_active: False
 gui_static_wan: False
+has_internet_connection: False
 
 # Set default for discovered hardware
 driver_name: nl80211

--- a/roles/1-prep/tasks/detected_network.yml
+++ b/roles/1-prep/tasks/detected_network.yml
@@ -53,19 +53,20 @@
   when: discovered_wan_iface != "none" and gw_active_test.stdout == "0"
 
 - name: Test for internet access
-  shell: wget "{{ xsce_download_url }}/heart-beat.txt" &> /dev/null ; echo $?
+  get_url: url="{{ xsce_download_url }}/heart-beat.txt" dest=/tmp/heart-beat.txt
+  ignore_errors: True
   async: 10
   poll: 2
   register: internet_access_test
 
-- name: Set has_internet_connection false by default
-  set_fact:
-     has_internet_connection: False
-
 - name: Set has_internet_connection true if wget succeeded
   set_fact:
      has_internet_connection: True
-  when: internet_access_test.stdout == "0"
+  when: internet_access_test
+
+- name: Cleanup internet test file
+  file: path=/tmp/heart-beat.txt
+        state=absent
 
 - name: Turn off downloads if no internet connection
   set_fact:


### PR DESCRIPTION
[fpaste of test](https://paste.fedoraproject.org/357233/52750146/)
Corrects Manash's failure when behind a proxy