### PR TITLE
need /etc/owncloud directory in fc24 too

### DIFF
--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -19,7 +19,6 @@
 - name: in Centos, the following config dir is symlink to /etc/owncloud
   file: path=/etc/owncloud
         state=directory
-  when: ansible_distribution == 'CentOS'
 
 - name: Add autoconfig file
   template: src=autoconfig.php.j2


### PR DESCRIPTION
creating a directory is needed in centos and fc24, so just do it unconditionlly