### PR TITLE
Defaults: make consistent -- install:true, enabled:false

### DIFF
--- a/ReleaseNotes6.1.md
+++ b/ReleaseNotes6.1.md
@@ -1,0 +1,25 @@
+# Release Notes for Release 6.1
+**What's New?**
+
+* Calibre -- A tool for managing a library of eBooks, modifyiing their file formats, adding search terms, and making them availabe online.
+* Wordpress -- A content management system which gives students experience with editing wiki pages, blogs, menuing systems, and which is widely used.
+* Dokuwiki -- An alternate wiki system, similar to wordpress, but less popular, which makes transferring wiki materials easy from one school server to another.
+* Schooltool -- An administrative tool for teachers and principals to record student rosters, grade books,  school calendars, and make some or all this information available online, and in printed form.
+* Sugarizer -- Makes some of the sugar activities available to browser clients on laptops, and smart phones/tablets.
+* CUPS -- Common Unix Printing System provides the ability to connect to and share network or USB connected printers.
+
+**What's Upgraded?**
+
+* Moodle is now upgraded to version 3.1, the most recent (long term support) version that will be supported until May 2019.
+* Elgg -- A social networking application is upgraded to 2.1.
+* Owncloud -- Permits sharing of all kinds of content between clients of a local server that is not internet connected (version 9).
+
+**Do all these new Services Slow my Server down?**
+
+A service that is installed on your hard disk, but not enabled in the administrative console, will have no impact on computer speed (will not use cpu cycles, or occupy scarce memory resources).  The XSCE default is to install everything, and only enable the few things which are essential for a server to operate.
+
+If you want to enable a service, you must browse to http://schoolserver.lan/admin, and click on configure, services enabled, and the appropriate checkbox. In addition, many services require additional content to be downloaded, which can also be accomplished by selecting the "Install Content" header button.
+
+**How Do I Install 6.1?**
+
+The install instructions have not changed much since release-6.0. Please refer to https://github.com/XSCE/xsce/wiki/XSCE-Installation

--- a/installer/livecd/Fedora-22/ks.cfg
+++ b/installer/livecd/Fedora-22/ks.cfg
@@ -15,7 +15,7 @@ network --hostname=schoolserver --device=link
 %packages
 wget
 git
-ansible
+ansible1.9
 python-pip
 @basic-desktop
 openbox

--- a/installer/livecd/Fedora-23/ks.cfg
+++ b/installer/livecd/Fedora-23/ks.cfg
@@ -15,7 +15,7 @@ network --hostname=schoolserver --device=link
 %packages
 wget
 git
-ansible
+ansible1.9
 python-pip
 patch
 

--- a/roles/elgg/defaults/main.yml
+++ b/roles/elgg/defaults/main.yml
@@ -1,4 +1,5 @@
-elgg_xx: elgg-1.10.1
+elgg_xx: elgg
+elgg_version: 2.1
 
 # elgg_mysql_password: defined in default_vars
 elgg_url: /elgg
@@ -7,6 +8,7 @@ elgg_install: True
 elgg_enabled: False
 
 # following variables used in elgg engine/settings.php template
+timezone: America/New_York
 dbuser: elgguser
 dbpassword: "{{ elgg_mysql_password }}"
 dbname: elggdb

--- a/roles/elgg/tasks/main.yml
+++ b/roles/elgg/tasks/main.yml
@@ -1,14 +1,10 @@
 - name: Get the ELGG software
-  get_url: url="{{ xsce_download_url }}/{{ elgg_xx }}.zip"  dest={{ downloads_dir}}/{{ elgg_xx }}.zip
+  git:  name=https://github.com/Elgg/Elgg
+        version={{ elgg_version }}
+        dest=/opt/elgg
   when: not {{ use_cache }} and not {{ no_network }}
   tags:
     - download2
-
-- name: Copy it to permanent location /opt
-  unarchive: src={{ downloads_dir}}/{{ elgg_xx }}.zip  dest=/opt/
-
-- name: Create a symbolic link to the folder of the current version elgg_xx
-  file: path=/opt/elgg src=./{{ elgg_xx }} state=link
 
 # elggdb.sql obtained with mysqldump --skip-add-drop-table elggdb > elggdb.sql
 
@@ -63,7 +59,7 @@
 
 #- use template to fix up settings in engine/settings.php with our variables substituted into engine/settings.example.php
 - name: Substitute our parameters in engine/settings.example.php
-  template: src="/opt/{{ elgg_xx }}/engine/settings.example.php"
+  template: src="/opt/{{ elgg_xx }}/elgg-config/settings.example.php"
             dest="/opt/{{ elgg_xx }}/engine/settings.php"
             owner=apache
 

--- a/roles/moodle/defaults/main.yml
+++ b/roles/moodle/defaults/main.yml
@@ -1,4 +1,4 @@
-moodle_version: 30
+moodle_version: 31
 moodle_repo_url: "https://github.com/moodle/moodle.git"
 moodle_base: "{{ xsce_base }}/moodle"
 moodle_user: moodle

--- a/roles/owncloud/defaults/main.yml
+++ b/roles/owncloud/defaults/main.yml
@@ -5,7 +5,6 @@ owncloud_url: /owncloud
 owncloud_path: "/opt/owncloud"
 owncloud_data_dir: /library/owncloud/data
 owncloud_dl_url: https://download.owncloud.org/community/
-owncloud_src_file: owncloud-7.0.12.tar.bz2
 
 # we install on mysql with these setting or those from default_vars, etc.
 owncloud_dbname: owncloud

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -1,4 +1,5 @@
-# we need to install the rpm in order to get the dependencies
+- name: Get the stable release channel repo definition
+  template: src=ce:stable.repo dest=/etc/yum.repos.d/
 
 - name: Install owncloud package
   yum: pkg={{ item }} state=installed
@@ -13,7 +14,7 @@
 
 - name: Override owncloud path when using rpms
   set_fact: 
-    owncloud_path: "/usr/share/owncloud"
+    owncloud_path: "/var/www/html/owncloud"
   when: not is_F18
 
 - name: in Centos, the following config dir is symlink to /etc/owncloud

--- a/roles/owncloud/templates/ce:stable.repo
+++ b/roles/owncloud/templates/ce:stable.repo
@@ -1,0 +1,7 @@
+[ce_stable]
+name=ownCloud Server Version stable (CentOS_7)
+type=rpm-md
+baseurl=http://download.owncloud.org/download/repositories/stable/CentOS_7
+gpgcheck=1
+gpgkey=http://download.owncloud.org/download/repositories/stable/CentOS_7/repodata/repomd.xml.key
+enabled=1

--- a/vars/default_vars.yml
+++ b/vars/default_vars.yml
@@ -146,7 +146,7 @@ postgresql_enabled: False
 
 # authserver
 authserver_install: True
-authserver_enabled: True
+authserver_enabled: False
 
 # usb-lib
 usb_lib_install: True
@@ -164,12 +164,12 @@ cups_enabled: False
 
 # ejabberd
 ejabberd_install: True
-ejabberd_enabled: True
+ejabberd_enabled: False
 
 # idmgr and activity-server
 idmgr_install: True
 activity-server_install: True
-xo_services_enabled: True
+xo_services_enabled: False
 
 # 6-GENERIC-APPS
 
@@ -208,7 +208,7 @@ moodle_enabled: False
 
 # Internet-in-a-Box
 iiab_install: True
-iiab_enabled: True
+iiab_enabled: False
 
 # Pathagar
 pathagar_install: True
@@ -289,7 +289,7 @@ awstats_enabled: False
 
 # xovis
 xovis_install: True
-xovis_enabled: True
+xovis_enabled: False	
 xovis_target_host: "127.0.0.1:5984"
 xovis_deployment_name: olpc
 


### PR DESCRIPTION
The current defaults show up in admin console, and don't make much sense on centos, or fc23