### PR TITLE
undefined variable in 0-once when wifi_id was moved from 1-prep

### DIFF
--- a/roles/0-once/defaults/main.yml
+++ b/roles/0-once/defaults/main.yml
@@ -15,3 +15,4 @@ xsce_prepped: False
 admin_console_path: "{{ xsce_base }}/admin_console"
 cmdsrv_path: "{{ xsce_base }}/xsce_cmdsrv"
 xsce_cmdsrv_dbname : "xsce_cmdsrv.0.2.db"
+wifi_id: none

--- a/roles/1-prep/defaults/main.yml
+++ b/roles/1-prep/defaults/main.yml
@@ -24,7 +24,6 @@ is_F24: False
 
 # Set default for discovered hardware
 driver_name: nl80211
-wifi_id: none
 rpi_model: none
 xo_model: none
 rtc_id: none


### PR DESCRIPTION
The failure this fixes was at 0-once/xo.yml line 19