### PR TITLE
abandon owncloud channels approach,which has different versions, and …

### DIFF
--- a/roles/owncloud/defaults/main.yml
+++ b/roles/owncloud/defaults/main.yml
@@ -5,6 +5,7 @@ owncloud_url: /owncloud
 owncloud_path: "/opt/owncloud"
 owncloud_data_dir: /library/owncloud/data
 owncloud_dl_url: https://download.owncloud.org/community/
+owncloud_src_file: owncloud-9.0.2.tar.bz2
 
 # we install on mysql with these setting or those from default_vars, etc.
 owncloud_dbname: owncloud

--- a/roles/owncloud/defaults/main.yml
+++ b/roles/owncloud/defaults/main.yml
@@ -2,7 +2,7 @@ owncloud_install: True
 owncloud_enabled: False
 
 owncloud_url: /owncloud
-owncloud_path: "/opt/owncloud"
+owncloud_path: "/opt"
 owncloud_data_dir: /library/owncloud/data
 owncloud_dl_url: https://download.owncloud.org/community/
 owncloud_src_file: owncloud-9.0.2.tar.bz2

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -21,6 +21,7 @@
 - name: Copy it to permanent location /opt
   unarchive: src={{ downloads_dir }}/{{ owncloud_src_file }}  
              dest={{ owncloud_path }}
+             creates={{ owncloud_path }}/owncloud/version.php
 
 - name: in Centos, the following config dir is symlink to /etc/owncloud
   file: path=/etc/owncloud

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -18,11 +18,6 @@
   tags:
     - download2
 
-# the following unarchive module needs the target directory to exist
-- name: Create Owncloud directory
-  file: path={{ owncloud_path }}
-        state=directory
-
 - name: Copy it to permanent location /opt
   unarchive: src={{ downloads_dir }}/{{ owncloud_src_file }}  
              dest={{ owncloud_path }}

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -18,6 +18,11 @@
   tags:
     - download2
 
+# the following unarchive module needs the target directory to exist
+- name: Create Owncloud directory
+  file: path={{ owncloud_path }}
+        state=directory
+
 - name: Copy it to permanent location /opt
   unarchive: src={{ downloads_dir }}/{{ owncloud_src_file }}  
              dest={{ owncloud_path }}

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: Add autoconfig file
   template: src=autoconfig.php.j2
-            dest={{ owncloud_path }}/config/autoconfig.php
+            dest={{ owncloud_path }}/owncloud/config/autoconfig.php
             owner=apache
             group=apache
             mode=0640

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -35,7 +35,7 @@
             mode=0640
 
 - name: Make apache owner
-  file: path={{ owncloud_path }}
+  file: path={{ owncloud_path }}/owncloud
         owner=apache
         group=apache
         recurse=yes

--- a/roles/owncloud/tasks/main.yml
+++ b/roles/owncloud/tasks/main.yml
@@ -1,21 +1,26 @@
-- name: Get the stable release channel repo definition
-  template: src=ce:stable.repo dest=/etc/yum.repos.d/
-
+# we need to install the rpm in order to get the dependencies
 - name: Install owncloud package
   yum: pkg={{ item }} state=installed
   with_items:
-  - owncloud
+      - owncloud
   tags:
-    - download
+      - download
 
-- name: Use tar file for F18
-  include: F18.yml
-  when: is_F18
+- name: Remove /etc/owncloud to avoid confusion as we use the config in {{ owncloud_path }}/config/
+  file: path=/etc/owncloud
+        state=absent
 
-- name: Override owncloud path when using rpms
-  set_fact: 
-    owncloud_path: "/var/www/html/owncloud"
-  when: not is_F18
+# but we use the tar file to get the latest version
+
+- name: Get the owncloud software
+  get_url: url="{{ xsce_download_url }}"/{{ owncloud_src_file }}  dest={{ downloads_dir }}/{{ owncloud_src_file }}
+  when: not {{ use_cache }} and not {{ no_network }}
+  tags:
+    - download2
+
+- name: Copy it to permanent location /opt
+  unarchive: src={{ downloads_dir }}/{{ owncloud_src_file }}  
+             dest={{ owncloud_path }}
 
 - name: in Centos, the following config dir is symlink to /etc/owncloud
   file: path=/etc/owncloud


### PR DESCRIPTION
It it's ok with everyone, I'd like to go back to having our own copy of what we install. It turned out that armv7l was back on version .8.x, and between .8 and .9 they moved the target location to /var/www/html.

We'd be having to rewrite the playbook next time around.
Not yet tested, but for discussion at our thursday call. 