### PR TITLE
f18 does not have ansible_machine_id

### DIFF
--- a/roles/1-prep/tasks/computed_vars.yml
+++ b/roles/1-prep/tasks/computed_vars.yml
@@ -53,8 +53,6 @@
       value: '{{ ansible_memtotal_mb }}'
     - option: 'swap_mb'
       value: '{{ ansible_swaptotal_mb }}'
-    - option: 'machine_id'
-      value: '{{ ansible_machine_id }}'
     - option: 'product_id'
       value: '{{ ansible_product_uuid }}'
 


### PR DESCRIPTION
TK tested this on xo1.5