### PR TITLE
Increase assessment item download timeout

### DIFF
--- a/roles/kalite/tasks/install.yml
+++ b/roles/kalite/tasks/install.yml
@@ -37,14 +37,14 @@
 
 - name: Download khan assessments
   get_url: url={{ khan_assessment_url }} dest={{ downloads_dir }}/khan_assessment.zip
-  async: 2000
+  async: 4000
   tags:
     - download2
 
 - name: wait until the file becomes available
   wait_for: path={{ downloads_dir }}/khan_assessment.zip
             state=present
-            timeout=2000
+            timeout=4000
 
 - name: Install kalite with pip
   pip: name={{ item }}


### PR DESCRIPTION
The current value of the assessment item download timeout consistently causes a fail on my 'fast' Indian internet. I would recommend to increase the same.