### PR TITLE
The overlapping text in Chrome is due to the '.content-item ul' CSS class defined in home.css

### DIFF
--- a/roles/2-common/files/html/css/home.css
+++ b/roles/2-common/files/html/css/home.css
@@ -83,7 +83,7 @@ b { font-weight: bold; }
 
 .content-item ul {
     float: left;  /* float keeps ul from flowing under thumbnail,  */
-    width: 1000px; /* defining max available width keeps float from */
+    /* width: 1000px; commenting out as this was causing text to go outside content box in certain cases (9/15); defining max available width keeps float from */
                   /* squishing multiple columns too closely */
     margin: 10px 0 10px 0;
     font-size: 80%;


### PR DESCRIPTION
The overlapping text in Chrome is due to the '.content-item ul' CSS class defined in home.css