### PR TITLE
ansible ownership change fails -- do in install script

### DIFF
--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -104,13 +104,6 @@
 - name: Execute moodle startup script
   shell: '{{moodle_base}}/moodle_installer'
   when: moodle_enabled and config.stat.exists is defined and not config.stat.exists
-  
-- name: Give apache permission to read config file
-  file: path={{ moodle_base }}/config.php
-        group=apache
-        mode=0640
-        state=file
-  when: moodle_enabled
 
 - name: add moodle to service list
   ini_file: dest='{{ service_filelist }}'

--- a/roles/moodle/templates/moodle_installer
+++ b/roles/moodle/templates/moodle_installer
@@ -5,3 +5,4 @@ sudo -u apache /usr/bin/php {{moodle_base}}/admin/cli/install.php \
 --fullname=Your_School --shortname=School \
 --adminuser=admin --adminpass=changeme \
 --non-interactive --agree-license
+chown apahce:apache {{ moodle_base }}/config.php


### PR DESCRIPTION
Don't know why the ansible module did not change ownership.  I tried waiting for the file to exist before changing ownership.  Finally just changing ownership in install script seemed the most direct