### PR TITLE
move br0 to interfaces, disable resolvconf

### DIFF
--- a/roles/1-prep/tasks/computed_vars.yml
+++ b/roles/1-prep/tasks/computed_vars.yml
@@ -38,8 +38,6 @@
       value: '{{ ansible_local["local_facts"]["xsce_branch"] }}'
     - option: 'runtime_commit'
       value: '{{ ansible_local["local_facts"]["xsce_commit"] }}'
-    - option: 'xsce_uuid'
-      value: '{{ ansible_local["local_facts"]["xsce_uuid"] }}'
     - option: 'runtime_date'
       value: '{{ ansible_date_time["iso8601"] }}'
     - option: 'runtime_php'

--- a/roles/network/tasks/debian.yml
+++ b/roles/network/tasks/debian.yml
@@ -18,16 +18,31 @@
 - debug: var=discovered_wireless_iface
 - debug: var=gui_static_wan
 
-- name: Get the stock resolv.conf manager
+- name: in upgrade from earlier 6.2, delete the resolvconf
   package: name=resolvconf
+           state=absent
+           enabled=False
+  ignore_errors: True
+
+- name: Get the dhcp client daemon used in recent raspbian
+  package: name=dhcpcd-dbus
            state=present
+
+- name: start up the dhcpcd service
+  service: name=dhcpcd
+           enabled=True
+           state=started
+
+- name: for upgrades from earlier 6.2, remove br0 file
+  file: path=/etc/network/interfaces.d/br0
+        state=absent
 
 - name: default to lan controller
   set_fact:
       gui_desired_network_role: "lan_controller"
   when: not gui_desired_network_role is defined
 
-- name: Copy the bridge script 
+- name: Copy the bridge script -- was in interfaces.d/
   template: dest=/etc/network/interfaces
             src=network/interfaces.j2
   register: interface

--- a/roles/network/tasks/rpi_debian.yml
+++ b/roles/network/tasks/rpi_debian.yml
@@ -18,6 +18,15 @@
   package: name=resolvconf
            state=present
 
+- name: recent raspbian uses dhcpcd rather than resolvconf
+  service: name=resolvconf
+           enabled=False
+           state=stopped
+
+- name: on upgrade from earlier xsce versions, remove /etc/network/interfaces.d/br0
+  file: path=/etc/network/interfaces.d/br0
+        state=absent
+
 - name: default to lan controller
   set_fact:
       gui_desired_network_role: "LanController"
@@ -28,9 +37,9 @@
        discovered_wireless_iface: wlan0
        discovered_wan_iface: eth0
        
-- name: Copy the bridge script 
-  template: dest=/etc/network/interfaces.d/br0
-            src=network/br0.j2
+- name: Copy the network config script -- previously in /etc/network/interfaces.d/br0 
+  template: dest=/etc/network/interfaces
+            src=network/interfaces.j2
   register: interface
 
 - name: If this was a change, things need to shift

--- a/roles/network/templates/network/interfaces.j2
+++ b/roles/network/templates/network/interfaces.j2
@@ -21,10 +21,8 @@ iface {{discovered_wireless_iface }} inet manual
 auto {{ discovered_wan_iface }}
 {% if gui_static_wan == false %}
 iface {{ discovered_wan_iface }} inet dhcp
-    pre-up ip link set br0 down && brctl delbr br0
 {% else %} # gui_static_wan_ip is set 
 iface {{ discovered_wan_iface }} inet static
-    pre-up ip link set br0 down && brctl delbr br0
     address {{ gui_static_wan_ip }}
     netmask {{ gui_static_wan_netmask }}
     gateway {{ gui_static_wan_gateway }}
@@ -37,12 +35,12 @@ auto br0
 iface br0 inet static
     bridge_ports {% if discovered_wireless_iface != "none" %} {{ discovered_wireless_iface }} {% endif %} {% if discovered_lan_iface != "none" %} {{ discovered_lan_iface }} {% endif %}
 
+    bridge_maxwait 0
     address {{ lan_ip }}
     netmask {{ lan_netmask }}
     dns-nameservers {{ lan_ip }}
-auto {{ discovered_wan_iface }}
 {% if gui_static_wan == false %}
-iface {{ discovered_wan_iface }} inet dhcp
+iface {{ discovered_wan_iface }} inet manual
 {% else %} # gui_static_wan_ip is set 
 iface {{ discovered_wan_iface }} inet static
     address {{ gui_static_wan_ip }}
@@ -58,6 +56,8 @@ iface {{ discovered_wan_iface }} inet static
 auto br0
 iface br0 inet static
     bridge_ports {% if discovered_wireless_iface != "none" %} {{ discovered_wireless_iface }} {% endif %} {% if discovered_wan_iface != "none" %} {{ discovered_wan_iface }} {% endif %}
+
+    bridge_maxwait 0
     address {{ lan_ip }}
     netmask {{ lan_netmask }}
     gateway {{ lan_ip }}


### PR DESCRIPTION
testing to date:
applied to Josh's pixel and pixel-lite images. results:
   pixel: reboot went from 3:02 to 0:44
   lite: reboot went from 3:55 to 0:31
without ethernet: pixel reboots in 0:31
"box" and "box.lan" still resolve on attached client

No testing on other-than-rpi