### PR TITLE
Start

### DIFF
--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -17,7 +17,7 @@
     - httpd
     - php
     - php-curl
-    - php-sqlite
+#    - php-sqlite
   tags:
     - download
   when: not is_debian

--- a/roles/openvpn/tasks/main.yml
+++ b/roles/openvpn/tasks/main.yml
@@ -23,6 +23,10 @@
         group=root
         mode=0755
 
+- name: Create a folder for xsce executable not on path
+  file: path=/usr/lib/xsce
+        state=directory
+
 - name: Configure openvpn
   template: src={{ item.src }}
             dest={{ item.dest }}
@@ -41,6 +45,7 @@
     - { src: 'xs-vpn', dest: '/usr/bin/xs-vpn', owner: "root" , mode: '0755' }
     - { src: 'xs-handle', dest: '/usr/bin/xs-handle', owner: "root" , mode: '0755' }
     - { src: 'up_wan', dest: '/usr/lib/xsce/up_wan', owner: "root" , mode: '0755' }
+    - { src: 'start.j2', dest: '/usr/lib/xsce/start', owner: "root" , mode: '0755' }
 
 - name: put up_wan in place for debian
   template: src=up_wan dest=/usr/lib/xsce/up_wan
@@ -69,7 +74,7 @@
 
 - name: make openvpn connection automatic
   lineinfile: dest=/etc/crontab
-            line="25 *  *  *  * root (/usr/bin/systemctl restart openvpn@xscenet.service) > /dev/null"
+            line="25 *  *  *  * root (/usr/bin/systemctl start openvpn@xscenet.service) > /dev/null"
   when:
             openvpn_enabled and openvpn_cron_enabled and not stat.exists is defined
 

--- a/roles/openvpn/templates/15-openvpn
+++ b/roles/openvpn/templates/15-openvpn
@@ -13,14 +13,16 @@ if [ "$2" = "up" ]; then
     sleep 2
     /sbin/ip route list dev "$1" | grep -q '^default' &&
     # restart the services
-    systemctl -q is-enabled openvpn@xscenet.service && systemctl restart openvpn@xscenet.service
+    systemctl -q is-enabled openvpn@xscenet.service && /usr/lib/xsce/up-wan
 fi
 
-if [ "$2" = "down" ]; then
-    sleep 2
-    /sbin/ip route list dev "$1" | grep -q '^default' ||
+# we added this to prevent logs from filling with openvpn errors
+#  but we do not expect openvpn to be on in that case
+#if [ "$2" = "down" ]; then
+#    sleep 2
+#    /sbin/ip route list dev "$1" | grep -q '^default' ||
     # stop the services
-    systemctl -q is-enabled openvpn@xscenet.service && systemctl stop openvpn@xscenet.service
-fi
+#    systemctl -q is-enabled openvpn@xscenet.service && systemctl stop openvpn@xscenet.service
+#fi
 
 exit 0

--- a/roles/openvpn/templates/announcer
+++ b/roles/openvpn/templates/announcer
@@ -25,5 +25,5 @@ HANDLE=${HANDLE// /_}
 ID=`printf "HANDLE = %s|UUID = %s|" $HANDLE $UUID`
 $SERVER -l -k -p1705 --exec "/bin/echo $ID" &
 {% else %}
-daemon --pidfile=${PID_FILE} $SERVER "-l -k -p1705 --exec \"/usr/bin/echo $(printf 'HANDLE = %s|UUID = %s\' $HANDLE $UUID)\"' &
+daemon --pidfile=${PID_FILE} $SERVER "-l -k -p1705 --exec \"/usr/bin/echo $(printf 'HANDLE = %s|UUID = %s' $HANDLE $UUID)\"" &
 {% endif %}

--- a/roles/openvpn/templates/start.j2
+++ b/roles/openvpn/templates/start.j2
@@ -1,0 +1,27 @@
+$!/bin/bash
+$ start the openvpn tunnel if the service is enabled
+
+enabled={{ openvpn_enabled }}
+VPNIP-{{ openvpn_server_port }}
+
+if [ "$enabled" = 'True' ]; then
+	# make sure the wan is functioning
+	# 8.8.8.8 is one of google's dns servers
+	ping -c 3 -i 3 8.8.8.8
+	if [ $? -ne 0 ]; then
+		#echo "internet is not available, tunnel not possible"
+		exit 1
+	fi
+	
+	# check the vpn tunnel
+	ping -c 5 -i 5 "$VPNIP"
+	# a zero return means the tunnel is up
+	if [ $? -eq 0 ]; then
+                exit 0
+        else
+		killall openvpn
+		sleep 10
+		#echo "Starting openvpn and waiting 10 seconds for daemon to become ready"
+                systemctl start openvpn@xscenet
+	fi
+fi

--- a/roles/openvpn/templates/up_wan
+++ b/roles/openvpn/templates/up_wan
@@ -4,6 +4,6 @@ systemctl is-enabled openvpn
 if [ $? -eq 0 ]; then
    pgrep openvpn
    if [ $? -ne 0 ]; then
-      service openvpn start xscenet
+      systemctl start openvpn@xscenet
    fi
 fi

--- a/roles/xsce-admin/tasks/console.yml
+++ b/roles/xsce-admin/tasks/console.yml
@@ -74,6 +74,12 @@
             owner=root
             group=root
             mode=0644
+  when: adm_cons_force_ssl and is_fedora
+
+- name: Remove admin-console ssl config file
+  file: path=/etc/{{ apache_config_dir }}/xs-console-ssl.conf
+        state=absent
+  when: not adm_cons_force_ssl and is_fedora
 
 - name: Remove the debian default config which gets in the way
   file: dest=/etc/apache2/sites-enabled/000-default.conf

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,6 +1,7 @@
 is_debian: false
 is_debuntu: false
 is_centos: true
+is_fedora: true
 is_redhat: true
 dns_service: named
 dns_user: named


### PR DESCRIPTION
Adam's Centos openvpn was falling off vpn. There was a race condition where systemd started openvpn, and the NetworkManager dispatcher stopped it by doing the restart. Changed from restart to start in NM. Test for openvpn function rather than always restart in crontab.