### PR TITLE
centos fix

### DIFF
--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -17,7 +17,8 @@
     - httpd
     - php
     - php-curl
-    - php-sqlite
+# centos does not have
+#    - php-sqlite
   tags:
     - download
   when: not is_debian

--- a/vars/centos.localvars
+++ b/vars/centos.localvars
@@ -1,0 +1,29 @@
+# Put variables for your installation that override defaults here
+# Better still, put this file in a branch of https://github.com/XSCE/iiab-local for your deployment
+
+#iiab_admin_user: iiab-admin
+
+# obtain a password hash with - python -c 'import crypt; print crypt.crypt("<plaintext>", "$6$<salt>")'
+#iiab_admin_passw_hash: 
+varible: value
+# 4-server-options
+authserver_install: False
+authserver_enabled: False
+# 5-xoservices
+xo_services_install: True
+ejabberd_install: False
+ejabberd_enabled: False
+idmgr_install: True
+debian_schooltool_install: False
+# 6-generic-aps
+# 7-edu-aps
+pathagar_install: False
+# 8-mgmat-tools
+sugar_stats_install: False
+ajenti_install: False
+monit_install: True
+xovis_install: False
+teamviewer_install: False
+activity_server_enabled: True
+
+


### PR DESCRIPTION
I discovered that the centos install works with more recent pip and setup tools -- so I modified http://download.iiab.io/6.2/x86/centos-load.txt to include "pip install -U pip setuptools"