### PR TITLE
Default pathagar to False in debian.localvars

### DIFF
--- a/vars/debian.localvars
+++ b/vars/debian.localvars
@@ -17,7 +17,7 @@ idmgr_install: False
 debian_schooltool_install: False
 # 6-generic-aps
 # 7-edu-aps
-pathagar_install: True
+pathagar_install: False
 # 8-mgmat-tools
 sugar_stats_install: False
 ajenti_install: False


### PR DESCRIPTION
Default pathagar to match [IIAB](https://github.com/iiab/iiab/search?utf8=%E2%9C%93&q=pathagar_install&type=)